### PR TITLE
Use site_url() instead of $_SERVER['SERVER_NAME'].

### DIFF
--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -700,7 +700,7 @@ Class WPOA {
 		if ( !current_user_can( 'manage_options' ) )  {
 			wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
 		}
-		$blog_url = "http://" . rtrim($_SERVER['SERVER_NAME'], "/") . "/";
+		$blog_url = site_url();
 		include 'wp-oauth-settings.php';
 	}
 } // END OF WPOA CLASS


### PR DESCRIPTION
Use WordPress function site_url() instead $_SERVER['SERVER_NAME'] to get a better result. When WP is running "in cloud" (behind proxy/loadbalancer...) the SERVER_NAME will be misleading here.
