### PR TITLE
Add Google Hosted Domain support

### DIFF
--- a/login-google.php
+++ b/login-google.php
@@ -9,6 +9,7 @@ define('HTTP_UTIL', get_option('wpoa_http_util'));
 define('CLIENT_ENABLED', get_option('wpoa_google_api_enabled'));
 define('CLIENT_ID', get_option('wpoa_google_api_id'));
 define('CLIENT_SECRET', get_option('wpoa_google_api_secret'));
+define( 'CLIENT_HD', get_option('wpoa_google_api_hd') ); // PROVIDER SPECIFIC: limits access to google account using this domain
 define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
 define('SCOPE', 'profile'); // PROVIDER SPECIFIC: 'profile' is the minimum scope required to get the user's id from Google
 define('URL_AUTH', "https://accounts.google.com/o/oauth2/auth?");
@@ -77,6 +78,7 @@ function get_oauth_code($wpoa) {
 	$params = array(
 		'response_type' => 'code',
 		'client_id' => CLIENT_ID,
+		'hd' => CLIENT_HD,
 		'scope' => SCOPE,
 		'state' => uniqid('', true),
 		'redirect_uri' => REDIRECT_URI,

--- a/wp-oauth-settings.php
+++ b/wp-oauth-settings.php
@@ -20,7 +20,7 @@
 		$points_max = 6;
 		return floor(($points / $points_max) * 100);
 	}
-	
+
 	// config check privacy
 	function wpoa_cc_privacy() {
 		$points = 0;
@@ -31,7 +31,7 @@
 		$points_max = 1;
 		return floor(($points / $points_max) * 100);
 	}
-	
+
 	// config check user experience
 	function wpoa_cc_ux() {
 		$points = 0;
@@ -44,7 +44,7 @@
 		$points_max = 2;
 		return floor(($points / $points_max) * 100);
 	}
-	
+
 	// cache the config check ratings:
 	$cc_security = wpoa_cc_security();
 	$cc_privacy = wpoa_cc_privacy();
@@ -75,10 +75,10 @@
 		<div id="wpoa-settings-section-news" class="wpoa-settings-section">
 			<h3>News</h3>
 			<div class='form-padding'>
-				<?php 
+				<?php
 				$rss = fetch_feed("http://glassocean.net/tag/wp-oauth/feed/");
 				if (!is_wp_error($rss)) {
-					$maxitems = $rss->get_item_quantity(5); 
+					$maxitems = $rss->get_item_quantity(5);
 					$rss_items = $rss->get_items(0, $maxitems);
 				}
 				?>
@@ -183,7 +183,7 @@
 					<p class="tip-message">Shows a short-lived notification message to the user which indicates whether or not the login was successful, and if there was an error.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Login redirects to: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -200,7 +200,7 @@
 					<p class="tip-message">Specifies where to redirect a user after they log in.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Logout redirects to: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -218,7 +218,7 @@
 					<p class="tip-message">Specifies where to redirect a user after they log out.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Automatically logout inactive users: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -241,19 +241,19 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END General Settings section -->
-			
+
 			<!-- START Login Page & Form Customization section -->
 			<div id="wpoa-settings-section-login-forms" class="wpoa-settings-section">
 			<h3>Login Forms</h3>
 			<div class='form-padding'>
 			<table class='form-table'>
-				
+
 				<tr valign='top'>
 				<th colspan="2">
 					<h4>Default Login Form / Page / Popup</h4>
 				</th>
 				</td>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Hide the WordPress login form: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -262,7 +262,7 @@
 					<p class="tip-message tip-warning"><strong>Warning: </strong>Hiding the WordPress login form may prevent you from being able to login. If you normally rely on this method, DO NOT enable this setting. Furthermore, please make sure your login provider(s) are active and working BEFORE enabling this setting.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Logo links to site: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -270,7 +270,7 @@
 					<p class="tip-message">Forces the logo image on the login form to link to your site instead of WordPress.org.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Logo image: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -281,7 +281,7 @@
 					<p class="tip-message">Changes the default WordPress logo on the login form to an image of your choice. You may select an image from the Media Library, or specify a custom URL.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Background image: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -292,13 +292,13 @@
 					<p class="tip-message">Changes the background on the login form to an image of your choice. You may select an image from the Media Library, or specify a custom URL.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th colspan="2">
 					<h4>Custom Login Forms</h4>
 				</th>
 				</td>
-			
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Custom form to show on the login screen: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -306,7 +306,7 @@
 					<p class="tip-message">Create or manage these login form designs in the CUSTOM LOGIN FORM DESIGNS section.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Custom form to show on the user's profile page: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -314,7 +314,7 @@
 					<p class="tip-message">Create or manage these login form designs in the CUSTOM LOGIN FORM DESIGNS section.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Custom form to show in the comments section: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -348,14 +348,14 @@
 				</td>
 				</tr>
 			</table> <!-- .form-table -->
-			
+
 			<table class="form-table" id="wpoa-login-form-design-form">
 				<tr valign='top'>
 				<th colspan="2">
 					<h4>Edit Design</h4>
 				</th>
 				</td>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Design name: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -363,7 +363,7 @@
 					<p class="tip-message">Sets the name to use for this design.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Icon set: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -374,7 +374,7 @@
 					<p class="tip-message">Specifies which icon set to use for displaying provider icons on the login buttons.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Show login buttons: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -386,7 +386,7 @@
 					<p class="tip-message">Determines when the login buttons should be shown.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Show logout button: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -398,7 +398,7 @@
 					<p class="tip-message">Determines when the logout button should be shown.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Layout: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -411,7 +411,7 @@
 					<p class="tip-message">Sets vertical or horizontal layout for the buttons.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Login button prefix: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -419,7 +419,7 @@
 					<p class="tip-message">Sets the text prefix to be displayed on the social login buttons.</p>
 				</td>
 				</tr>
-			
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Logged out title: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -427,7 +427,7 @@
 					<p class="tip-message">Sets the text to be displayed above the login form for logged out users.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Logged in title: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -435,7 +435,7 @@
 					<p class="tip-message">Sets the text to be displayed above the login form for logged in users.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Logging in title: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -443,7 +443,7 @@
 					<p class="tip-message">Sets the text to be displayed above the login form for users who are logging in.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Logging out title: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -451,14 +451,14 @@
 					<p class="tip-message">Sets the text to be displayed above the login form for users who are logging out.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' id='wpoa-login-form-actions'>
 				<th scope='row'>
 					<input type="button" id="wpoa-login-form-ok" name="wpoa_login_form_ok" class="button" value="OK">
 					<input type="button" id="wpoa-login-form-cancel" name="wpoa_login_form_cancel" class="button" value="Cancel">
 				</th>
 				<td>
-					
+
 				</td>
 				</tr>
 			</table> <!-- .form-table -->
@@ -466,7 +466,7 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END Login Buttons section -->
-			
+
 			<!-- START User Registration section -->
 			<div id="wpoa-settings-section-user-registration" class="wpoa-settings-section">
 			<h3>User Registration</h3>
@@ -479,7 +479,7 @@
 					<p class="tip-message">Prevents WordPress from sending an email to newly registered users by default, which contains their username and password.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Assign new users to the following role: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -492,7 +492,7 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END User Registration section -->
-			
+
 			<!-- START Login with Google section -->
 			<div id="wpoa-settings-section-login-with-google" class="wpoa-settings-section">
 			<h3>Login with Google</h3>
@@ -504,11 +504,11 @@
 					<input type='checkbox' name='wpoa_google_api_enabled' value='1' <?php checked(get_option('wpoa_google_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>Client ID:</th>
 				<td>
-					<input type='text' name='wpoa_google_api_id' value='<?php echo get_option('wpoa_google_api_id'); ?>' />
+					<input type='text' name='wpoa_google_api_id' value='<?php echo get_option( 'wpoa_google_api_id' ); ?>' />
 				</td>
 				</tr>
 
@@ -518,6 +518,14 @@
 					<input type='text' name='wpoa_google_api_secret' value='<?php echo get_option('wpoa_google_api_secret'); ?>' />
 				</td>
 				</tr>
+
+				<tr valign='top'>
+				<th scope='row'>Hosted Domain: <small>(Optional)</small></th>
+				<td>
+					<input type='text' name='wpoa_google_api_hd' value='<?php echo esc_html( get_option('wpoa_google_api_hd') ); ?>' />
+				</td>
+				</tr>
+
 			</table> <!-- .form-table -->
 			<p>
 				<strong>Instructions:</strong>
@@ -526,14 +534,15 @@
 					<li>At Google, create a new Project and enable the Google+ API. This will enable your site to access the Google+ API.</li>
 					<li>At Google, provide your site's homepage URL (<?php echo $blog_url; ?>) for the new Project's Redirect URI. Don't forget the trailing slash!</li>
 					<li>At Google, you must also configure the Consent Screen with your Email Address and Product Name. This is what Google will display to users when they are asked to grant access to your site/app.</li>
-					<li>Paste your Client ID/Secret provided by Google into the fields above, then click the Save all settings button.</li>
+					<li>Paste your Client ID/Secret provided by Google into the fields above.</li>
+					<li>If you wish to limit access to a Google Apps Hosted Domain paste is it the field above eg, example.com, then click the Save all settings button.</li>
 				</ol>
 			</p>
 			<?php submit_button('Save all settings'); ?>
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END Login with Google section -->
-			
+
 			<!-- START Login with Facebook section -->
 			<div id="wpoa-settings-section-login-with-facebook" class="wpoa-settings-section">
 			<h3>Login with Facebook</h3>
@@ -545,14 +554,14 @@
 					<input type='checkbox' name='wpoa_facebook_api_enabled' value='1' <?php checked(get_option('wpoa_facebook_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>App ID:</th>
 				<td>
 					<input type='text' name='wpoa_facebook_api_id' value='<?php echo get_option('wpoa_facebook_api_id'); ?>' />
 				</td>
 				</tr>
-				 
+
 				<tr valign='top'>
 				<th scope='row'>App Secret:</th>
 				<td>
@@ -573,7 +582,7 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END Login with Facebook section -->
-			
+
 			<!-- START Login with LinkedIn section -->
 			<div id="wpoa-settings-section-login-with-linkedin" class="wpoa-settings-section">
 			<h3>Login with LinkedIn</h3>
@@ -585,14 +594,14 @@
 					<input type='checkbox' name='wpoa_linkedin_api_enabled' value='1' <?php checked(get_option('wpoa_linkedin_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>API Key:</th>
 				<td>
 					<input type='text' name='wpoa_linkedin_api_id' value='<?php echo get_option('wpoa_linkedin_api_id'); ?>' />
 				</td>
 				</tr>
-				 
+
 				<tr valign='top'>
 				<th scope='row'>Secret Key:</th>
 				<td>
@@ -613,7 +622,7 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END Login with LinkedIn section -->
-			
+
 			<!-- START Login with Github section -->
 			<div id="wpoa-settings-section-login-with-github" class="wpoa-settings-section">
 			<h3>Login with Github</h3>
@@ -625,14 +634,14 @@
 					<input type='checkbox' name='wpoa_github_api_enabled' value='1' <?php checked(get_option('wpoa_github_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>Client ID:</th>
 				<td>
 					<input type='text' name='wpoa_github_api_id' value='<?php echo get_option('wpoa_github_api_id'); ?>' />
 				</td>
 				</tr>
-				 
+
 				<tr valign='top'>
 				<th scope='row'>Client Secret:</th>
 				<td>
@@ -653,7 +662,7 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END Login with Github section -->
-			
+
 			<!-- START Login with Reddit section -->
 			<div id="wpoa-settings-section-login-with-reddit" class="wpoa-settings-section">
 			<h3>Login with Reddit</h3>
@@ -665,14 +674,14 @@
 					<input type='checkbox' name='wpoa_reddit_api_enabled' value='1' <?php checked(get_option('wpoa_reddit_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>Client ID:</th>
 				<td>
 					<input type='text' name='wpoa_reddit_api_id' value='<?php echo get_option('wpoa_reddit_api_id'); ?>' />
 				</td>
 				</tr>
-				 
+
 				<tr valign='top'>
 				<th scope='row'>Client Secret:</th>
 				<td>
@@ -693,7 +702,7 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END Login with Reddit section -->
-			
+
 			<!-- START Login with Windows Live section -->
 			<div id="wpoa-settings-section-login-with-windowslive" class="wpoa-settings-section">
 			<h3>Login with Windows Live</h3>
@@ -705,14 +714,14 @@
 					<input type='checkbox' name='wpoa_windowslive_api_enabled' value='1' <?php checked(get_option('wpoa_windowslive_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>Client ID:</th>
 				<td>
 					<input type='text' name='wpoa_windowslive_api_id' value='<?php echo get_option('wpoa_windowslive_api_id'); ?>' />
 				</td>
 				</tr>
-				 
+
 				<tr valign='top'>
 				<th scope='row'>Client Secret:</th>
 				<td>
@@ -745,7 +754,7 @@
 					<input type='checkbox' name='wpoa_paypal_api_enabled' value='1' <?php checked(get_option('wpoa_paypal_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>Sandbox mode:</th>
 				<td>
@@ -753,14 +762,14 @@
 					<p class="tip-message">PayPal offers a sandbox mode for developers who wish to setup and test PayPal Login with their site before going live.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>Client ID:</th>
 				<td>
 					<input type='text' name='wpoa_paypal_api_id' value='<?php echo get_option('wpoa_paypal_api_id'); ?>' />
 				</td>
 				</tr>
-				 
+
 				<tr valign='top'>
 				<th scope='row'>Client Secret:</th>
 				<td>
@@ -795,14 +804,14 @@
 					<input type='checkbox' name='wpoa_instagram_api_enabled' value='1' <?php checked(get_option('wpoa_instagram_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>Client ID:</th>
 				<td>
 					<input type='text' name='wpoa_instagram_api_id' value='<?php echo get_option('wpoa_instagram_api_id'); ?>' />
 				</td>
 				</tr>
-				 
+
 				<tr valign='top'>
 				<th scope='row'>Client Secret:</th>
 				<td>
@@ -841,14 +850,14 @@
 					<input type='checkbox' name='wpoa_battlenet_api_enabled' value='1' <?php checked(get_option('wpoa_battlenet_api_enabled') == 1); ?> />
 				</td>
 				</tr>
-				
+
 				<tr valign='top'>
 				<th scope='row'>Key:</th>
 				<td>
 					<input type='text' name='wpoa_battlenet_api_id' value='<?php echo get_option('wpoa_battlenet_api_id'); ?>' />
 				</td>
 				</tr>
-				 
+
 				<tr valign='top'>
 				<th scope='row'>Secret:</th>
 				<td>
@@ -856,7 +865,7 @@
 				</td>
 				</tr>
 			</table> <!-- .form-table -->
-			
+
 			<p>
 				<strong>Instructions:</strong>
 				<ol>
@@ -877,7 +886,7 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END Login with Battle.net section -->
-			
+
 			<!-- START Back Channel Configuration section -->
 			<div id="wpoa-settings-section-back-channel=configuration" class="wpoa-settings-section">
 			<h3>Back Channel Configuration</h3>
@@ -894,7 +903,7 @@
 					<p class="tip-message">The method used by the web server for performing HTTP requests to the third-party providers. Most servers support cURL, but some servers may require Stream Context instead.</p>
 				</td>
 				</tr>
-				
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Verify Peer/Host SSL Certificates: <a href="#" class="tip-button">[?]</a></th>
 				<td>
@@ -908,7 +917,7 @@
 			</div> <!-- .form-padding -->
 			</div> <!-- .wpoa-settings-section -->
 			<!-- END Back Channel Configuration section -->
-			
+
 			<!-- START Maintenance & Troubleshooting section -->
 			<div id="wpoa-settings-section-maintenance-troubleshooting" class="wpoa-settings-section">
 			<h3>Maintenance & Troubleshooting</h3>
@@ -921,7 +930,7 @@
 					<p class="tip-message"><strong>Instructions:</strong> Check the box above, click the Save all settings button, and the settings will be restored to default.</p>
 					<p class="tip-message tip-warning"><strong>Warning:</strong> This will restore the default settings, erasing any API keys/secrets that you may have entered above.</p>
 				</td>
-				</tr>		
+				</tr>
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Delete settings on uninstall: <a href="#" class="tip-button">[?]</a></th>
 				<td>

--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -22,7 +22,7 @@ Class WPOA {
 
 	// set a version that we can use for performing plugin updates, this should always match the plugin version:
 	const PLUGIN_VERSION = "0.4";
-	
+
 	// singleton class pattern:
 	protected static $instance = NULL;
 	public static function get_instance() {
@@ -82,6 +82,7 @@ Class WPOA {
 		'wpoa_google_api_enabled' => 0,									// 0, 1
 		'wpoa_google_api_id' => '',										// any string
 		'wpoa_google_api_secret' => '',									// any string
+		'wpoa_google_api_hd' => '',										// any string
 		'wpoa_facebook_api_enabled' => 0,								// 0, 1
 		'wpoa_facebook_api_id' => '',									// any string
 		'wpoa_facebook_api_secret' => '',								// any string
@@ -112,7 +113,7 @@ Class WPOA {
 		'wpoa_restore_default_settings' => 0,							// 0, 1
 		'wpoa_delete_settings_on_uninstall' => 0,						// 0, 1
 	);
-	
+
 	// when the plugin class gets created, fire the initialization:
 	function __construct() {
 		// hook activation and deactivation for the plugin:
@@ -123,7 +124,7 @@ Class WPOA {
 		// hook init event to handle plugin initialization:
 		add_action('init', array($this, 'init'));
 	}
-	
+
 	// a wrapper for wordpress' get_option(), this basically feeds get_option() the setting's correct default value as specified at the top of this file:
 	/*
 	function wpoa_option($name) {
@@ -132,15 +133,15 @@ Class WPOA {
 		return $val;
 	}
 	*/
-	
+
 	// do something during plugin activation:
 	function wpoa_activate() {
 	}
-	
+
 	// do something during plugin deactivation:
 	function wpoa_deactivate() {
 	}
-	
+
 	// do something during plugin update:
 	function wpoa_update() {
 		$plugin_version = WPOA::PLUGIN_VERSION;
@@ -155,7 +156,7 @@ Class WPOA {
 			add_action('admin_notices', array($this, 'wpoa_update_notice'));
 		}
 	}
-	
+
 	// indicate to the admin that the plugin has been updated:
 	function wpoa_update_notice() {
 		$settings_link = "<a href='options-general.php?page=WP-OAuth.php'>Settings Page</a>"; // CASE SeNsItIvE filename!
@@ -165,7 +166,7 @@ Class WPOA {
 		</div>
 		<?php
 	}
-	
+
 	// adds any missing settings and their default values:
 	function wpoa_add_missing_settings() {
 		foreach($this->settings as $setting_name => $default_value) {
@@ -176,7 +177,7 @@ Class WPOA {
 			$added = add_option($setting_name, $default_value);
 		}
 	}
-	
+
 	// restores the default plugin settings:
 	function wpoa_restore_default_settings() {
 		foreach($this->settings as $setting_name => $default_value) {
@@ -188,7 +189,7 @@ Class WPOA {
 		}
 		add_action('admin_notices', array($this, 'wpoa_restore_default_settings_notice'));
 	}
-	
+
 	// indicate to the admin that the plugin has been updated:
 	function wpoa_restore_default_settings_notice() {
 		$settings_link = "<a href='options-general.php?page=WP-OAuth.php'>Settings Page</a>"; // CASE SeNsItIvE filename!
@@ -234,7 +235,7 @@ Class WPOA {
 			add_filter('login_footer', array($this, 'wpoa_push_login_messages'));
 		}
 	}
-	
+
 	// init scripts and styles for use on FRONTEND PAGES:
 	function wpoa_init_frontend_scripts_styles() {
 		// here we "localize" php variables, making them available as a js variable in the browser:
@@ -260,7 +261,7 @@ Class WPOA {
 		wp_enqueue_script('wpoa-script', plugin_dir_url( __FILE__ ) . 'wp-oauth.js', array());
 		wp_enqueue_style('wpoa-style', plugin_dir_url( __FILE__ ) . 'wp-oauth.css', array());
 	}
-	
+
 	// init scripts and styles for use on BACKEND PAGES:
 	function wpoa_init_backend_scripts_styles() {
 		// here we "localize" php variables, making them available as a js variable in the browser:
@@ -287,7 +288,7 @@ Class WPOA {
 		// load the default wordpress media screen:
 		wp_enqueue_media();
 	}
-	
+
 	// init scripts and styles for use on the LOGIN PAGE:
 	function wpoa_init_login_scripts_styles() {
 		// here we "localize" php variables, making them available as a js variable in the browser:
@@ -316,25 +317,25 @@ Class WPOA {
 		wp_enqueue_script('wpoa-script', plugin_dir_url( __FILE__ ) . 'wp-oauth.js', array());
 		wp_enqueue_style('wpoa-style', plugin_dir_url( __FILE__ ) . 'wp-oauth.css', array());
 	}
-	
+
 	// add a settings link to the plugins page:
 	function wpoa_settings_link($links) {
 		$settings_link = "<a href='options-general.php?page=WP-OAuth.php'>Settings</a>"; // CASE SeNsItIvE filename!
-		array_unshift($links, $settings_link); 
-		return $links; 
+		array_unshift($links, $settings_link);
+		return $links;
 	}
-	
+
 	// ===============
 	// GENERIC HELPERS
 	// ===============
-	
+
 	// adds basic http auth to a given url string:
 	function wpoa_add_basic_auth($url, $username, $password) {
 		$url = str_replace("https://", "", $url);
 		$url = "https://" . $username . ":" . $password . "@" . $url;
 		return $url;
 	}
-	
+
 	// ===================
 	// LOGIN FLOW HANDLING
 	// ===================
@@ -347,7 +348,7 @@ Class WPOA {
 		$vars[] = 'error_message';
 		return $vars;
 	}
-	
+
 	// handle the querystring triggers:
 	function wpoa_qvar_handlers() {
 		if (get_query_var('connect')) {
@@ -363,7 +364,7 @@ Class WPOA {
 			$this->wpoa_include_connector($provider);
 		}
 	}
-	
+
 	// load the provider script that is being requested by the user or being called back after authentication:
 	function wpoa_include_connector($provider) {
 		// normalize the provider name (no caps, no spaces):
@@ -373,7 +374,7 @@ Class WPOA {
 		// include the provider script:
 		include 'login-' . $provider . '.php';
 	}
-	
+
 	// =======================
 	// LOGIN / LOGOUT HANDLING
 	// =======================
@@ -389,7 +390,7 @@ Class WPOA {
 		$user = get_user_by('id', $query_result);
 		return $user;
 	}
-	
+
 	// login (or register and login) a wordpress user based on their oauth identity:
 	function wpoa_login_user($oauth_identity) {
 		// store the user info in the user session so we can grab it later if we need to register the user:
@@ -425,7 +426,7 @@ Class WPOA {
 		// we shouldn't be here, but just in case...
 		$this->wpoa_end_login("Sorry, we couldn't log you in. The login flow terminated in an unexpected way. Please notify the admin or try again later.");
 	}
-	
+
 	// ends the login request by clearing the login state and redirecting the user to the desired page:
 	function wpoa_end_login($msg) {
 		$last_url = $_SESSION["WPOA"]["LAST_URL"];
@@ -458,7 +459,7 @@ Class WPOA {
 		wp_safe_redirect($redirect_url);
 		die();
 	}
-	
+
 	// logout the wordpress user:
 	// TODO: this is usually called from a custom logout button, but we could have the button call /wp-logout.php?action=logout for more consistency...
 	function wpoa_logout_user() {
@@ -467,7 +468,7 @@ Class WPOA {
 		session_destroy(); 	// destroy the php user session
 		wp_logout(); 		// logout the wordpress user...this gets hooked and diverted to wpoa_end_logout() for final handling
 	}
-	
+
 	// ends the logout request by redirecting the user to the desired page:
 	function wpoa_end_logout() {
 		$_SESSION["WPOA"]["RESULT"] = 'Logged out successfully.';
@@ -509,7 +510,7 @@ Class WPOA {
 		wp_safe_redirect($redirect_url);
 		die();
 	}
-	
+
 	// links a third-party account to an existing wordpress user account:
 	function wpoa_link_account($user_id) {
 		if ($_SESSION['WPOA']['USER_ID'] != '') {
@@ -540,14 +541,14 @@ Class WPOA {
 		// wp-ajax requires death:
 		die();
 	}
-	
+
 	// pushes login messages into the dom where they can be extracted by javascript:
 	function wpoa_push_login_messages() {
 		$result = $_SESSION['WPOA']['RESULT'];
 		$_SESSION['WPOA']['RESULT'] = '';
 		echo "<div id='wpoa-result'>" . $result . "</div>";
 	}
-	
+
 	// clears the login state:
 	function wpoa_clear_login_state() {
 		unset($_SESSION["WPOA"]["USER_ID"]);
@@ -557,7 +558,7 @@ Class WPOA {
 		unset($_SESSION["WPOA"]["EXPIRES_AT"]);
 		//unset($_SESSION["WPOA"]["LAST_URL"]);
 	}
-	
+
 	// ===================================
 	// DEFAULT LOGIN SCREEN CUSTOMIZATIONS
 	// ===================================
@@ -566,7 +567,7 @@ Class WPOA {
 	function wpoa_logo_link() {
 		return get_bloginfo('url');
 	}
-	
+
 	// show a custom login form on the default login screen:
 	function wpoa_customize_login_screen() {
 		$html = "";
@@ -581,7 +582,7 @@ Class WPOA {
 	// ===================================
 	// DEFAULT COMMENT FORM CUSTOMIZATIONS
 	// ===================================
-	
+
 	// show a custom login form at the top of the default comment form:
 	function wpoa_customize_comment_form_fields($fields) {
 		$html = "";
@@ -593,7 +594,7 @@ Class WPOA {
 		}
 		return $fields;
 	}
-	
+
 	// show a custom login form at the top of the default comment form:
 	function wpoa_customize_comment_form() {
 		$html = "";
@@ -608,7 +609,7 @@ Class WPOA {
 	// =========================
 	// LOGIN / LOGOUT COMPONENTS
 	// =========================
-	
+
 	// shortcode which allows adding the wpoa login form to any post or page:
 	function wpoa_login_form( $atts ){
 		$a = shortcode_atts( array(
@@ -633,7 +634,7 @@ Class WPOA {
 		$html = $this->wpoa_login_form_content($a['design'], $a['icon_set'], $a['layout'], $a['button_prefix'], $a['align'], $a['show_login'], $a['show_logout'], $a['logged_out_title'], $a['logged_in_title'], $a['logging_in_title'], $a['logging_out_title'], $a['style'], $a['class']);
 		return $html;
 	}
-	
+
 	// gets the content to be used for displaying the login/logout form:
 	function wpoa_login_form_content($design = '', $icon_set = 'icon_set', $layout = 'links-column', $button_prefix = '', $align = 'left', $show_login = 'conditional', $show_logout = 'conditional', $logged_out_title = 'Please login:', $logged_in_title = 'You are already logged in.', $logging_in_title = 'Logging in...', $logging_out_title = 'Logging out...', $style = '', $class = '') { // even though wpoa_login_form() will pass a default, we might call this function from another method so it's important to re-specify the default values
 		// if a design was specified and that design exists, load the shortcode attributes from that design:
@@ -682,7 +683,7 @@ Class WPOA {
 		$html .= "</div>";
 		return $html;
 	}
-	
+
 	// generate and return the login buttons, depending on available providers:
 	function wpoa_login_buttons($icon_set, $button_prefix) {
 		// generate the atts once (cache them), so we can use it for all buttons without computing them each time:
@@ -729,7 +730,7 @@ Class WPOA {
 		}
 		return $html;
 	}
-	
+
 	// output the custom login form design selector:
 	function wpoa_login_form_designs_selector($id = '', $master = false) {
 		$html = "";
@@ -753,7 +754,7 @@ Class WPOA {
 		}
 		return $html;
 	}
-	
+
 	// returns a saved login form design as a shortcode atts string or array for direct use via the shortcode
 	function wpoa_get_login_form_design($design_name, $as_string = false) {
 		$designs_json = get_option('wpoa_login_form_designs');
@@ -776,7 +777,7 @@ Class WPOA {
 		}
 		return $atts;
 	}
-	
+
 	function wpoa_login_form_design_exists($design_name) {
 		$designs_json = get_option('wpoa_login_form_designs');
 		$designs_array = json_decode($designs_json, true);
@@ -793,7 +794,7 @@ Class WPOA {
 			return false;
 		}
 	}
-	
+
 	// shows the user's linked providers, used on the 'Your Profile' page:
 	function wpoa_linked_accounts() {
 		// get the current user:
@@ -841,18 +842,18 @@ Class WPOA {
 		echo "</td>";
 		echo "</table>";
 	}
-	
+
 	// ====================
 	// PLUGIN SETTINGS PAGE
 	// ====================
-	
+
 	// registers all settings that have been defined at the top of the plugin:
 	function wpoa_register_settings() {
 		foreach ($this->settings as $setting_name => $default_value) {
 			register_setting('wpoa_settings', $setting_name);
 		}
 	}
-	
+
 	// add the main settings page:
 	function wpoa_settings_page() {
 		add_options_page( 'WP-OAuth Options', 'WP-OAuth', 'manage_options', 'WP-OAuth', array($this, 'wpoa_settings_page_content') );


### PR DESCRIPTION
Hosted Domain is used to limit access to Google accounts from a
specified domain.
- Add hosted domain option to administration page
- Add HD parameter to Google API call

![screen shot 2015-03-29 at 11 41 28](https://cloud.githubusercontent.com/assets/1015212/6885099/e1a1b656-d608-11e4-84e8-b2f73b2ff656.png)

I've tested this in our corporate environment. May need some more testing as our setup handles failed login's slightly different to the normal Google process. 
