### PR TITLE
Avoid php notice.

### DIFF
--- a/login-battlenet.php
+++ b/login-battlenet.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'Battle.net';

--- a/login-facebook.php
+++ b/login-facebook.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'Facebook';

--- a/login-github.php
+++ b/login-github.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'Github';

--- a/login-google.php
+++ b/login-google.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'Google';

--- a/login-instagram.php
+++ b/login-instagram.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'Instagram';

--- a/login-linkedin.php
+++ b/login-linkedin.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'LinkedIn';

--- a/login-paypal.php
+++ b/login-paypal.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'PayPal';

--- a/login-reddit.php
+++ b/login-reddit.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'Reddit';

--- a/login-windowslive.php
+++ b/login-windowslive.php
@@ -1,7 +1,9 @@
 <?php
 
 // start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 $_SESSION['WPOA']['PROVIDER'] = 'Windows Live';

--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -11,7 +11,9 @@ License: GPL2
 */
 
 // start the user session for persisting user/login state during ajax, header redirect, and cross domain calls:
-session_start();
+if (!isset($_SESSION)) {
+    session_start();
+}
 
 // plugin class:
 Class WPOA {

--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -545,9 +545,11 @@ Class WPOA {
 	
 	// pushes login messages into the dom where they can be extracted by javascript:
 	function wpoa_push_login_messages() {
-		$result = $_SESSION['WPOA']['RESULT'];
+		if (isset($_SESSION['WPOA']['RESULT'])) {
+			$result = $_SESSION['WPOA']['RESULT'];
+			echo "<div id='wpoa-result'>" . $result . "</div>";
+		}
 		$_SESSION['WPOA']['RESULT'] = '';
-		echo "<div id='wpoa-result'>" . $result . "</div>";
 	}
 	
 	// clears the login state:

--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -292,6 +292,11 @@ Class WPOA {
 	
 	// init scripts and styles for use on the LOGIN PAGE:
 	function wpoa_init_login_scripts_styles() {
+		if (isset($_SESSION['WPOA']['RESULT'])) {
+			$login_message = $_SESSION['WPOA']['RESULT'];
+		} else {
+			$login_message = '';
+		}
 		// here we "localize" php variables, making them available as a js variable in the browser:
 		$wpoa_cvars = array(
 			// basic info:
@@ -305,7 +310,7 @@ Class WPOA {
 			'hide_login_form' => get_option('wpoa_hide_wordpress_login_form'),
 			'logo_image' => get_option('wpoa_logo_image'),
 			'bg_image' => get_option('wpoa_bg_image'),
-			'login_message' => $_SESSION['WPOA']['RESULT'],
+			'login_message' => $login_message,
 			'show_login_messages' => get_option('wpoa_show_login_messages'),
 			'logout_inactive_users' => get_option('wpoa_logout_inactive_users'),
 			'logged_in' => is_user_logged_in(),


### PR DESCRIPTION
Avoid 'PHP Notice:  A session had already been started - ignoring session_start()'.
Simple fix: Don't start a new session if an old one is running.