### PR TITLE
Allow FORCE_SSL_ADMIN flag

### DIFF
--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -687,6 +687,7 @@ Class WPOA {
 	function wpoa_login_buttons($icon_set, $button_prefix) {
 		// generate the atts once (cache them), so we can use it for all buttons without computing them each time:
 		$site_url = get_bloginfo('url');
+		if( force_ssl_admin() ) { $site_url = set_url_scheme( $site_url, 'https' ); }
 		$redirect_to = urlencode($_GET['redirect_to']);
 		if ($redirect_to) {$redirect_to = "&redirect_to=" . $redirect_to;}
 		// get shortcode atts that determine how we should build these buttons:


### PR DESCRIPTION
When FORCE_SSL_ADMIN defined in wp-config.php, 
we should overwrite $site_url scheme to https to avoid scheme inconsistency in admin page.

# Reproduce procedure:

1. Set wordpress url + site url to be http://xxx
2. in wp-config.php, define( 'FORCE_SSL_ADMIN', true )
3. goto http://xxx/wp-admin, it will be redirected to https://xxx/wp-admin automatically
4. the oauth button should be href="https://xxx...." instead of "http://xxx..."