### PR TITLE
Create class for refactoring

### DIFF
--- a/logger.php
+++ b/logger.php
@@ -7,6 +7,7 @@ class Logger {
     private function __construct() {
 		error_log(Logger::BASE_NAME . "Creating logger");
         $this->debug = get_option('wpoa_debug_plugin') ? true : false;
+        $this->debug = true ;
     }
 
 

--- a/logger.php
+++ b/logger.php
@@ -1,15 +1,15 @@
 <?php
 
 class Logger {
-    private $display;
+    private $debug;
 
-    function __construct() {
-        $debug = getoption('wpao_debug_plugin');    
+    private function __construct() {
+        $this->debug = get_option('wpao_debug_plugin');
     }
 
     
     public function dump($value) {
-        if ($debug === true) {
+        if ($this->debug === true) {
             ob_start();
             var_dump($value);
             $log = ob_get_clean();
@@ -19,7 +19,7 @@ class Logger {
     }
 
     public function print_stack_trace($value) {
-        if ($debug === true) {
+        if ($this->debug === true) {
             ob_start();
 		    debug_print_backtrace();
 		    $log = ob_get_clean();
@@ -30,12 +30,16 @@ class Logger {
 
     public function log($message)
     {
-        if ($debug === true) {
+        if ($this->debug === true) {
             error_log($message);
         }
     }
+
+    public static function Instance(){
+        static $logger = null;
+        if ($logger === null) {
+             $logger = new Logger();
+        }
+        return $logger;
+    }
 }
-
-global $logger;
-
-$logger = new Logger();

--- a/logger.php
+++ b/logger.php
@@ -4,7 +4,7 @@ class Logger {
     private $debug;
 
     private function __construct() {
-        $this->debug = get_option('wpao_debug_plugin');
+        $this->debug = get_option('wpoa_debug_plugin') ? true : false;
     }
 
     
@@ -13,7 +13,7 @@ class Logger {
             ob_start();
             var_dump($value);
             $log = ob_get_clean();
-            ob_end_clean();
+            ob_end_flush();
             error_log($log);
         }
     }

--- a/logger.php
+++ b/logger.php
@@ -1,0 +1,41 @@
+<?php
+
+class Logger {
+    private $display;
+
+    function __construct() {
+        $debug = getoption('wpao_debug_plugin');    
+    }
+
+    
+    public function dump($value) {
+        if ($debug === true) {
+            ob_start();
+            var_dump($value);
+            $log = ob_get_clean();
+            ob_end_clean();
+            error_log($log);
+        }
+    }
+
+    public function print_stack_trace($value) {
+        if ($debug === true) {
+            ob_start();
+		    debug_print_backtrace();
+		    $log = ob_get_clean();
+		    ob_end_clean();
+		    error_log($log);
+        }
+    }
+
+    public function log($message)
+    {
+        if ($debug === true) {
+            error_log($message);
+        }
+    }
+}
+
+global $logger;
+
+$logger = new Logger();

--- a/logger.php
+++ b/logger.php
@@ -7,7 +7,7 @@ class Logger {
         $this->debug = get_option('wpoa_debug_plugin') ? true : false;
     }
 
-    
+
     public function dump($value) {
         if ($this->debug === true) {
             ob_start();
@@ -21,10 +21,10 @@ class Logger {
     public function print_stack_trace($value) {
         if ($this->debug === true) {
             ob_start();
-		    debug_print_backtrace();
-		    $log = ob_get_clean();
-		    ob_end_clean();
-		    error_log($log);
+            debug_print_backtrace();
+            $log = ob_get_clean();
+            ob_end_clean();
+            error_log($log);
         }
     }
 
@@ -38,7 +38,7 @@ class Logger {
     public static function Instance(){
         static $logger = null;
         if ($logger === null) {
-             $logger = new Logger();
+            $logger = new Logger();
         }
         return $logger;
     }

--- a/logger.php
+++ b/logger.php
@@ -2,8 +2,10 @@
 
 class Logger {
     private $debug;
+	const BASE_NAME = "WPOA: ";
 
     private function __construct() {
+		error_log(Logger::BASE_NAME . "Creating logger");
         $this->debug = get_option('wpoa_debug_plugin') ? true : false;
     }
 
@@ -14,7 +16,7 @@ class Logger {
             var_dump($value);
             $log = ob_get_clean();
             ob_end_flush();
-            error_log($log);
+            error_log(Logger::BASE_NAME . $log);
         }
     }
 
@@ -24,14 +26,14 @@ class Logger {
             debug_print_backtrace();
             $log = ob_get_clean();
             ob_end_clean();
-            error_log($log);
+            error_log(Logger::BASE_NAME . $log);
         }
     }
 
     public function log($message)
     {
         if ($this->debug === true) {
-            error_log($message);
+            error_log(Logger::BASE_NAME . $message);
         }
     }
 

--- a/login-battlenet.php
+++ b/login-battlenet.php
@@ -1,183 +1,40 @@
 <?php
 
 include_once 'session.php';
+include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('Battle.net');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_battlenet_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_battlenet_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_battlenet_api_secret'));
-define('REDIRECT_URI', rtrim(site_url('', 'https'), '/') . '/'); // PROVIDER SPECIFIC: Battle.net requires HTTPS
-define('SCOPE', ''); // PROVIDER SPECIFIC: Battle.net states that an empty scope will give us the user account ID
-define('URL_AUTH', "https://us.battle.net/oauth/authorize?");
-define('URL_TOKEN', "https://us.battle.net/oauth/token?");
-define('URL_USER', "https://us.api.battle.net/account/user/id?");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
+error_reporting(E_ALL | E_STRICT);
 
-WPOA_Session::save_last_url();
+class LoginBattlenet extends AbstractLoginCommon {
+  public function __construct($wpoa) {
+    parent::__construct('Battle.net', 
+      "https://us.battle.net/oauth/authorize?",
+      "https://us.battle.net/oauth/token?",
+      "https://us.api.battle.net/account/user/id?",
+      $wpoa);
+    //$this->useBearer = true;
+	//$this->sendIdAndSecretInHeader = true;
+  }
 
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
-	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
+  
+  function getOAuthCodeExtendArray($array) {
+    return $array;
+  }
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
-	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
+  function getOAuthIdentityParameters(){
+    return array("schema" => "openid",
+                 "access_token" => WPOA_Session::get_token());
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+    // TODO : Battlenet only send id. If they implement name and email, we must update the following line.
+	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['id'];
+    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['id'] . "@battle.net";
+
+    return $oauth_identity;
+  }
 }
 
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			// PROVIDER NORMALIZATION: PayPal requires Accept and Accept-Language headers, Reddit requires sending a User-Agent header
-			// PROVIDER NORMALIZATION: PayPal/Reddit requires sending the client id/secret via http basic authentication
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, (get_option('wpoa_http_util_verify_ssl') == 1 ? 1 : 0));
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, (get_option('wpoa_http_util_verify_ssl') == 1 ? 2 : 0));
-			$result = curl_exec($curl);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_TOKEN, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	$result_obj = json_decode($result, true); // PROVIDER SPECIFIC: Google encodes the access token result as json by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Google returns the access token KEEP THIS PROTECTED!
-	$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: this is how Google returns the access token's expiration
-	$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
-}
-
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access_token is passed to Google via POST param
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_USER . $url_params; // TODO: we probably want to send this using a curl_setopt...
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			// PROVIDER NORMALIZATION: Github/Reddit require a User-Agent here...
-			// PROVIDER NORMALIZATION: PayPal/Reddit require that we send the access token via a bearer header, PayPal also requires a Content-Type: application/json header...
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			$result = curl_exec($curl);
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github User-Agent
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
-	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
-	return $oauth_identity;
-}
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
+$login = new LoginBattlenet($this);
+$login->run();

--- a/login-battlenet.php
+++ b/login-battlenet.php
@@ -12,13 +12,6 @@ class LoginBattlenet extends AbstractLoginCommon {
                 "https://us.battle.net/oauth/token?",
                 "https://us.api.battle.net/account/user/id?",
                 $wpoa);
-        //$this->useBearer = true;
-        //$this->sendIdAndSecretInHeader = true;
-    }
-
-
-    function getOAuthCodeExtendArray($array) {
-        return $array;
     }
 
     function getOAuthIdentityParameters(){
@@ -30,7 +23,7 @@ class LoginBattlenet extends AbstractLoginCommon {
         $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
         // TODO : Battlenet only send id. If they implement name and email, we must update the following line.
         $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['id'];
-        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['id'] . "@battle.net";
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['id'] . "@example.net";
 
         return $oauth_identity;
     }

--- a/login-battlenet.php
+++ b/login-battlenet.php
@@ -171,10 +171,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
-	//$oauth_identity['email'] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
+	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-battlenet.php
+++ b/login-battlenet.php
@@ -6,34 +6,34 @@ include_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginBattlenet extends AbstractLoginCommon {
-  public function __construct($wpoa) {
-    parent::__construct('Battle.net', 
-      "https://us.battle.net/oauth/authorize?",
-      "https://us.battle.net/oauth/token?",
-      "https://us.api.battle.net/account/user/id?",
-      $wpoa);
-    //$this->useBearer = true;
-	//$this->sendIdAndSecretInHeader = true;
-  }
+    public function __construct($wpoa) {
+        parent::__construct('Battle.net',
+                "https://us.battle.net/oauth/authorize?",
+                "https://us.battle.net/oauth/token?",
+                "https://us.api.battle.net/account/user/id?",
+                $wpoa);
+        //$this->useBearer = true;
+        //$this->sendIdAndSecretInHeader = true;
+    }
 
-  
-  function getOAuthCodeExtendArray($array) {
-    return $array;
-  }
 
-  function getOAuthIdentityParameters(){
-    return array("schema" => "openid",
-                 "access_token" => WPOA_Session::get_token());
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
-    // TODO : Battlenet only send id. If they implement name and email, we must update the following line.
-	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['id'];
-    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['id'] . "@battle.net";
+    function getOAuthCodeExtendArray($array) {
+        return $array;
+    }
 
-    return $oauth_identity;
-  }
+    function getOAuthIdentityParameters(){
+        return array("schema" => "openid",
+                "access_token" => WPOA_Session::get_token());
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+        // TODO : Battlenet only send id. If they implement name and email, we must update the following line.
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['id'];
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['id'] . "@battle.net";
+
+        return $oauth_identity;
+    }
 }
 
 $login = new LoginBattlenet($this);

--- a/login-battlenet.php
+++ b/login-battlenet.php
@@ -1,12 +1,9 @@
 <?php
 
-// start the user session for maintaining individual user states during the multi-stage authentication flow:
-if (!isset($_SESSION)) {
-    session_start();
-}
+include_once 'session.php';
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-$_SESSION['WPOA']['PROVIDER'] = 'Battle.net';
+WPOA_Session::set_provider('Battle.net');
 define('HTTP_UTIL', get_option('wpoa_http_util'));
 define('CLIENT_ENABLED', get_option('wpoa_battlenet_api_enabled'));
 define('CLIENT_ID', get_option('wpoa_battlenet_api_id'));
@@ -18,17 +15,7 @@ define('URL_TOKEN', "https://us.battle.net/oauth/token?");
 define('URL_USER', "https://us.api.battle.net/account/user/id?");
 # END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-// remember the user's last url so we can redirect them back to there after the login ends:
-if (!$_SESSION['WPOA']['LAST_URL']) {
-	// try to obtain the redirect_url from the default login page:
-	$redirect_url = esc_url($_GET['redirect_to']);
-	// if no redirect_url was found, set it to the user's last page:
-	if (!$redirect_url) {
-		$redirect_url = strtok($_SERVER['HTTP_REFERER'], "?");
-	}
-	// set the user's last page so we can return that user there after they login:
-	$_SESSION['WPOA']['LAST_URL'] = $redirect_url;
-}
+WPOA_Session::save_last_url();
 
 # AUTHENTICATION FLOW #
 // the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
@@ -49,7 +36,7 @@ elseif (isset($_GET['error_message'])) {
 }
 elseif (isset($_GET['code'])) {
 	// post-auth phase, verify the state:
-	if ($_SESSION['WPOA']['STATE'] == $_GET['state']) {
+	if (WPOA_Session::get_state() == $_GET['state']) {
 		// get an access token from the third party provider:
 		get_oauth_token($this);
 		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
@@ -64,7 +51,7 @@ elseif (isset($_GET['code'])) {
 }
 else {
 	// pre-auth, start the auth process:
-	if ((empty($_SESSION['WPOA']['EXPIRES_AT'])) || (time() > $_SESSION['WPOA']['EXPIRES_AT'])) {
+	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
 		// expired token; clear the state:
 		$this->wpoa_clear_login_state();
 	}
@@ -83,7 +70,7 @@ function get_oauth_code($wpoa) {
 		'state' => uniqid('', true),
 		'redirect_uri' => REDIRECT_URI,
 	);
-	$_SESSION['WPOA']['STATE'] = $params['state'];
+	WPOA_Session::set_state($params['state']);
 	$url = URL_AUTH . http_build_query($params);
 	header("Location: $url");
 	exit;
@@ -139,9 +126,9 @@ function get_oauth_token($wpoa) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
 	}
 	else {
-		$_SESSION['WPOA']['ACCESS_TOKEN'] = $access_token;
-		$_SESSION['WPOA']['EXPIRES_IN'] = $expires_in;
-		$_SESSION['WPOA']['EXPIRES_AT'] = $expires_at;
+		WPOA_Session::set_token($access_token);
+		WPOA_Session::set_expires_in($expires_in);
+		WPOA_Session::set_expires_at($expires_at);
 		return true;
 	}
 }
@@ -150,7 +137,7 @@ function get_oauth_identity($wpoa) {
 	// here we exchange the access token for the user info...
 	// set the access token param:
 	$params = array(
-		'access_token' => $_SESSION['WPOA']['ACCESS_TOKEN'], // PROVIDER SPECIFIC: the access_token is passed to Google via POST param
+		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access_token is passed to Google via POST param
 	);
 	$url_params = http_build_query($params);
 	// perform the http request:
@@ -171,7 +158,7 @@ function get_oauth_identity($wpoa) {
 				array(
 					'method'  => 'GET',
 					// PROVIDER NORMALIZATION: Reddit/Github User-Agent
-					'header'  => "Authorization: Bearer " . $_SESSION['WPOA']['ACCESS_TOKEN'] . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
+					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
 				)
 			);
 			$context = $context  = stream_context_create($opts);
@@ -184,7 +171,7 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = $_SESSION['WPOA']['PROVIDER'];
+	$oauth_identity['provider'] = WPOA_Session::get_provider();
 	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
 	//$oauth_identity['email'] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
 	if (!$oauth_identity['id']) {

--- a/login-common.php
+++ b/login-common.php
@@ -2,7 +2,7 @@
 include_once "logger.php";
 
 function init_curl($url) {
-	$logger->log("CURL : Init with url = " . $url);
+	Logger::Instance()->log("CURL : Init with url = " . $url);
 	$curl = curl_init($url);
 	$verify_ssl= get_option('wpoa_http_util_verify_ssl');
 	curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, ($verify_ssl == 1 ? 1 : 0));
@@ -17,10 +17,10 @@ function exec_curl($curl, $message = "") {
 
     if(!$result) { 
       curl_error($curl);
-      $logger->log("CURL : error : " . $message);
+      Logger::Instance()->log("CURL : error : " . $message);
       trigger_error($error); 
     }
     curl_close($curl);
-    $logger->log("CURL : exec reult = " . $result);
+    Logger::Instance()->log("CURL : exec reult = " . $result);
     return $result;
 }

--- a/login-common.php
+++ b/login-common.php
@@ -122,7 +122,7 @@ abstract class AbstractLoginCommon {
         }
     }
 
-    function getOAuthCode() {
+    private function getOAuthCode() {
         Logger::Instance()->log($this->id . ": Get code");
         $params = array(
                 'response_type' => 'code',
@@ -140,7 +140,7 @@ abstract class AbstractLoginCommon {
     }
 
 
-    function getOAuthToken() {
+    private function getOAuthToken() {
         $logMessage = $this->id . ": Get Token";
         Logger::Instance()->log($logMessage);
         $params = array(
@@ -277,7 +277,7 @@ abstract class AbstractLoginCommon {
         return $result_obj;
     }
 
-    function getOAuthIdentity() {
+    private function getOAuthIdentity() {
         $result_obj = $this->getRequest($this->urlUser, $this->id . ": Get Identity");
         $result_obj = $this->getOauthIdentityPostTreatment($result_obj);
         $oauth_identity = array();
@@ -289,15 +289,21 @@ abstract class AbstractLoginCommon {
         return $oauth_identity;
     }
 
-
-    abstract function getOAuthCodeExtendArray($array);
-    abstract function getOAuthIdentityParameters();
-    abstract function getOAuthIdentityFillArray($result_obj, $oauth_identity);
-
-    function getOAuthTokenExtendArray($array) {
+    // Following function can be overloaded
+    protected function getOAuthCodeExtendArray($array) {
         return $array;
     }
-    function getOauthIdentityPostTreatment($result_obj) {
+
+    protected function getOAuthIdentityParameters(){
+        return array('access_token' => WPOA_Session::get_token());
+    }
+    
+    protected function getOAuthTokenExtendArray($array) {
+        return $array;
+    }
+    protected function getOauthIdentityPostTreatment($result_obj) {
         return $result_obj;
     }
+
+    abstract function getOAuthIdentityFillArray($result_obj, $oauth_identity);
 }

--- a/login-common.php
+++ b/login-common.php
@@ -4,300 +4,300 @@ require_once "logger.php";
 error_reporting(E_ALL | E_STRICT);
 
 function init_curl($url) {
-  Logger::Instance()->log("CURL : Init with url = " . $url);
-  $curl = curl_init($url);
-  $verify_ssl= get_option('wpoa_http_util_verify_ssl');
-  curl_setopt($curl, CURLOPT_URL, $url);
-  curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, ($verify_ssl == 1 ? 1 : 0));
-  curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, ($verify_ssl == 1 ? 2 : 0));
-  curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-  
-  //curl_setopt($curl, CURLOPT_VERBOSE, true);
-  //curl_setopt($curl, CURLOPT_STDERR, fopen('C:\tmp\php\wordpress\wp-content\debug.log', 'a'));
-  return $curl;
+    Logger::Instance()->log("CURL : Init with url = " . $url);
+    $curl = curl_init($url);
+    $verify_ssl= get_option('wpoa_http_util_verify_ssl');
+    curl_setopt($curl, CURLOPT_URL, $url);
+    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, ($verify_ssl == 1 ? 1 : 0));
+    curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, ($verify_ssl == 1 ? 2 : 0));
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+
+    //curl_setopt($curl, CURLOPT_VERBOSE, true);
+    //curl_setopt($curl, CURLOPT_STDERR, fopen('C:\tmp\php\wordpress\wp-content\debug.log', 'a'));
+    return $curl;
 }
 
 
 function exec_curl($curl, $message = "") {
-  $result = curl_exec($curl);
+    $result = curl_exec($curl);
 
-  if(!$result) {
-    $error = curl_error($curl);
-    Logger::Instance()->log("CURL : error : " . $message);
-    trigger_error($error);
-  }
-  
-  curl_close($curl);
-  Logger::Instance()->log("CURL : exec reult = " . $result);
-  return $result;
-  
+    if(!$result) {
+        $error = curl_error($curl);
+        Logger::Instance()->log("CURL : error : " . $message);
+        trigger_error($error);
+    }
+
+    curl_close($curl);
+    Logger::Instance()->log("CURL : exec reult = " . $result);
+    return $result;
+
 }
 
 abstract class AbstractLoginCommon {
-  private $id;
-  private $name;
-  private $wpoa;
-  
-  private $urlAuth;
-  private $urlToken;
-  private $urlUser;
-  
-  protected function getUrlUser() {
-    return $this->urlUser;
-  }
-  
-  private $clientEnabled;
-  private $clientId;
-  private $clientSecret;
-  
-  private $redirectUri;
+    private $id;
+    private $name;
+    private $wpoa;
 
-  private $requestMode;
-  
-  protected $useBearer = false;
-  protected $ignoreExpiresIn = false;
-  protected $sendIdAndSecretInHeader = false;
-    
-  protected function __construct($name, $urlAuth, $urlToken, $urlUser, $wpoa) {
-    $this->id = $this->clean($name);
-    $this->name = $name;
-    $this->wpoa = $wpoa;
-    
-    $this->urlAuth = $urlAuth;
-    $this->urlToken = $urlToken;
-    $this->urlUser = $urlUser;
-    $base = "wpoa_" . $this->id;
-    $this->clientEnabled = get_option($base . '_api_enabled');
-    $this->clientId = get_option($base . '_api_id');
-    $this->clientSecret = get_option($base . '_api_secret');
+    private $urlAuth;
+    private $urlToken;
+    private $urlUser;
 
-    Logger::Instance()->log("CONSTRUCT STATE : enabled = $this->clientEnabled / id = $this->clientId / secret = $this->clientSecret");
-    
-    $this->redirectUri = rtrim(site_url(), '/') . '/';
-    $this->requestMode = strtolower(get_option('wpoa_http_util'));
-  }
-  
-  private function clean($value) {
-    $result = strtolower($value);
-    $result = str_replace(" ", "", $result);
-    $result = str_replace(".", "", $result);
-    return $result;
-  }
-  
-  public function run() {
-    WPOA_Session::save_last_url();
-    WPOA_Session::set_provider($this->name);
-    if (!$this->clientEnabled) {
-      $this->wpoa->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
+    protected function getUrlUser() {
+        return $this->urlUser;
     }
-    elseif (!$this->clientId || !$this->clientSecret) {
-      $this->wpoa->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-    }
-    elseif (isset($_GET['error_description'])) {
-      $this->wpoa->wpoa_end_login($_GET['error_description']);
-    }
-    elseif (isset($_GET['error_message'])) {
-      $this->wpoa->wpoa_end_login($_GET['error_message']);
-    }
-    elseif (isset($_GET['code'])) {
-      if (WPOA_Session::get_state() == $_GET['state']) {
-        $this->getOAuthToken();
-        //         get the user's third-party identity and attempt to login/register a matching wordpress user account:
-        $oauth_identity = $this->getOAuthIdentity();
-        $this->wpoa->wpoa_login_user($oauth_identity);
-      }
-      else {
-        // possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-        // TODO: report detailed message to admin/logs here...
-        $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-      }
-    }
-    else {
-      // pre-auth, start the auth process:
-      if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-        // expired token; clear the state:
-        $this->wpoa->wpoa_clear_login_state();
-      }
-      $this->getOAuthCode();
-    }
-  }
 
-  function getOAuthCode() {
-    Logger::Instance()->log($this->id . ": Get code");
-    $params = array(
-      'response_type' => 'code',
-      'client_id' => $this->clientId,
-      'state' => uniqid('', true),
-      'redirect_uri' => $this->redirectUri,
-    );
-    $params = $this->getOAuthCodeExtendArray($params);
-    Logger::Instance()->dump($params);
-    WPOA_Session::set_state($params['state']);
-    $url = $this->urlAuth . http_build_query($params);
-    Logger::Instance()->log($this->id . ": Get Oauth code from : " . $url);
-    header("Location: $url");
-    exit;
-  }
-  
-    
-  function getOAuthToken() {
-    $logMessage = $this->id . ": Get Token";
-    Logger::Instance()->log($logMessage);
-    $params = array(
-      'grant_type' => 'authorization_code',
-      'client_id' => $this->clientId,
-      'client_secret' => $this->clientSecret,
-      'code' => $_GET['code'],
-      'redirect_uri' => $this->redirectUri,
-    );
-    $params = $this->getOAuthTokenExtendArray($params);
-    $url_params = http_build_query($params);
-    switch ($this->requestMode) {
-      case 'curl':
-        $url = $this->urlToken;
-        $curl = init_curl($url);
-        curl_setopt($curl, CURLOPT_POST, 1);
-        curl_setopt($curl, CURLOPT_POSTFIELDS, $url_params);
-        // PROVIDER NORMALIZATION: PayPal requires Accept and Accept-Language headers, Reddit requires sending a User-Agent header
-        // PROVIDER NORMALIZATION: PayPal/Reddit requires sending the client id/secret via http basic authentication
-        if ($this->sendIdAndSecretInHeader === true) {
-          Logger::Instance()->log($logMessage . " / Sending ID/Secret in header");
-          curl_setopt($curl, CURLOPT_USERPWD, $this->clientId . ":" . $this->clientSecret);
-          $encoded = base64_encode($this->clientId . ":" . $this->clientSecret);
-          $header = array("Accept: application/json", 
-                          "Accept-Language: en_US", 
-                          "Content-Type: application/x-www-form-urlencoded");
+    private $clientEnabled;
+    private $clientId;
+    private $clientSecret;
 
-          curl_setopt($curl, CURLOPT_HTTPHEADER, $header); 
+    private $redirectUri;
+
+    private $requestMode;
+
+    protected $useBearer = false;
+    protected $ignoreExpiresIn = false;
+    protected $sendIdAndSecretInHeader = false;
+
+    protected function __construct($name, $urlAuth, $urlToken, $urlUser, $wpoa) {
+        $this->id = $this->clean($name);
+        $this->name = $name;
+        $this->wpoa = $wpoa;
+
+        $this->urlAuth = $urlAuth;
+        $this->urlToken = $urlToken;
+        $this->urlUser = $urlUser;
+        $base = "wpoa_" . $this->id;
+        $this->clientEnabled = get_option($base . '_api_enabled');
+        $this->clientId = get_option($base . '_api_id');
+        $this->clientSecret = get_option($base . '_api_secret');
+
+        Logger::Instance()->log("CONSTRUCT STATE : enabled = $this->clientEnabled / id = $this->clientId / secret = $this->clientSecret");
+
+        $this->redirectUri = rtrim(site_url(), '/') . '/';
+        $this->requestMode = strtolower(get_option('wpoa_http_util'));
+    }
+
+    private function clean($value) {
+        $result = strtolower($value);
+        $result = str_replace(" ", "", $result);
+        $result = str_replace(".", "", $result);
+        return $result;
+    }
+
+    public function run() {
+        WPOA_Session::save_last_url();
+        WPOA_Session::set_provider($this->name);
+        if (!$this->clientEnabled) {
+            $this->wpoa->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
         }
-        $result = exec_curl($curl, $logMessage);
-        break;
-      case 'stream-context':
-        $url = rtrim($this->urlToken, "?");
-        $opts = array('http' =>
-          array(
-            'method'  => 'POST',
-            'header'  => 'Content-type: application/x-www-form-urlencoded',
-            'content' => $url_params,
-          )
-        );
-        $context = $context  = stream_context_create($opts);
-        $result = @file_get_contents($url, false, $context);
-        if ($result === false) {
-          $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
+        elseif (!$this->clientId || !$this->clientSecret) {
+            $this->wpoa->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
         }
-        break;
-    }
-      
-    $result_obj = json_decode($result, true);
-    if (!$result_obj) {
-      Logger::Instance()->log($this->id . ": Not a JSon item, parsing it");
-      $result_obj = $this->explode($result);
-      Logger::Instance()->dump($result_obj);
-    }
-    $access_token = $result_obj['access_token'];
-    $expires_in = $result_obj['expires_in'];
-    if (!$expires_in) {
-      $expires_in = $result_obj['expires'];
-    }
-
-    $expires_at = time() + $expires_in;
-  
-    if (!$access_token || (!$this->ignoreExpiresIn && !$expires_in)) {
-      // malformed access token result detected:
-      $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-    }
-    else {
-      WPOA_Session::set_token($access_token);
-      WPOA_Session::set_expires_in($expires_in);
-      WPOA_Session::set_expires_at($expires_at);
-      return true;
-    }
-  }
-
-  private function explode($input) {
-    $output = array();
-
-    $items = explode( '&', $input );
-
-    foreach( $items as $val ){
-        $tmp = explode( '=', $val );
-        $output[ $tmp[0] ] = $tmp[1];
-    }
-
-    return $output;
-  }
-
-  protected function getRequest($url, $message) {
-    Logger::Instance()->log($message . "->" . $url);
-    // here we exchange the access token for the user info...
-    // set the access token param:
-    $access_token = WPOA_Session::get_token();
-    Logger::Instance()->log($message. ": token = " .$access_token);
-    $params = $this->getOAuthIdentityParameters();
-    $url_params = http_build_query($params);
-    // perform the http request:
-    switch ($this->requestMode) {
-      case 'curl':
-        $url = rtrim($url, "?") . "?";
-        $url .= $url_params;
-        $curl = init_curl($url);
-        Logger::Instance()->log($message . ": Bearer $this->useBearer");
-        curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
-        if ($this->useBearer === true) {
-          Logger::Instance()->log($message . ": Using Bearer");
-          curl_setopt($curl, CURLOPT_URL, $url);
-          curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // TODO: does Windows Live require this?
-          $header = array("Authorization: Bearer " . $access_token, 
-                          "x-li-format: json");
-          curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
+        elseif (isset($_GET['error_description'])) {
+            $this->wpoa->wpoa_end_login($_GET['error_description']);
         }
-    
-        
-        $result = exec_curl($curl, "get oauth identity");
+        elseif (isset($_GET['error_message'])) {
+            $this->wpoa->wpoa_end_login($_GET['error_message']);
+        }
+        elseif (isset($_GET['code'])) {
+            if (WPOA_Session::get_state() == $_GET['state']) {
+                $this->getOAuthToken();
+                //         get the user's third-party identity and attempt to login/register a matching wordpress user account:
+                $oauth_identity = $this->getOAuthIdentity();
+                $this->wpoa->wpoa_login_user($oauth_identity);
+            }
+            else {
+                // possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
+                // TODO: report detailed message to admin/logs here...
+                $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
+            }
+        }
+        else {
+            // pre-auth, start the auth process:
+            if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
+                // expired token; clear the state:
+                $this->wpoa->wpoa_clear_login_state();
+            }
+            $this->getOAuthCode();
+        }
+    }
+
+    function getOAuthCode() {
+        Logger::Instance()->log($this->id . ": Get code");
+        $params = array(
+                'response_type' => 'code',
+                'client_id' => $this->clientId,
+                'state' => uniqid('', true),
+                'redirect_uri' => $this->redirectUri,
+                );
+        $params = $this->getOAuthCodeExtendArray($params);
+        Logger::Instance()->dump($params);
+        WPOA_Session::set_state($params['state']);
+        $url = $this->urlAuth . http_build_query($params);
+        Logger::Instance()->log($this->id . ": Get Oauth code from : " . $url);
+        header("Location: $url");
+        exit;
+    }
+
+
+    function getOAuthToken() {
+        $logMessage = $this->id . ": Get Token";
+        Logger::Instance()->log($logMessage);
+        $params = array(
+                'grant_type' => 'authorization_code',
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'code' => $_GET['code'],
+                'redirect_uri' => $this->redirectUri,
+                );
+        $params = $this->getOAuthTokenExtendArray($params);
+        $url_params = http_build_query($params);
+        switch ($this->requestMode) {
+            case 'curl':
+                $url = $this->urlToken;
+                $curl = init_curl($url);
+                curl_setopt($curl, CURLOPT_POST, 1);
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $url_params);
+                // PROVIDER NORMALIZATION: PayPal requires Accept and Accept-Language headers, Reddit requires sending a User-Agent header
+                // PROVIDER NORMALIZATION: PayPal/Reddit requires sending the client id/secret via http basic authentication
+                if ($this->sendIdAndSecretInHeader === true) {
+                    Logger::Instance()->log($logMessage . " / Sending ID/Secret in header");
+                    curl_setopt($curl, CURLOPT_USERPWD, $this->clientId . ":" . $this->clientSecret);
+                    $encoded = base64_encode($this->clientId . ":" . $this->clientSecret);
+                    $header = array("Accept: application/json", 
+                            "Accept-Language: en_US", 
+                            "Content-Type: application/x-www-form-urlencoded");
+
+                    curl_setopt($curl, CURLOPT_HTTPHEADER, $header); 
+                }
+                $result = exec_curl($curl, $logMessage);
+                break;
+            case 'stream-context':
+                $url = rtrim($this->urlToken, "?");
+                $opts = array('http' =>
+                        array(
+                            'method'  => 'POST',
+                            'header'  => 'Content-type: application/x-www-form-urlencoded',
+                            'content' => $url_params,
+                            )
+                        );
+                $context = $context  = stream_context_create($opts);
+                $result = @file_get_contents($url, false, $context);
+                if ($result === false) {
+                    $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
+                }
+                break;
+        }
+
         $result_obj = json_decode($result, true);
-        break;
-      case 'stream-context':
-        $url = rtrim($url, "?");
-        $opts = array('http' =>
-          array(
-            'method'  => 'GET',
-            // PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
-            'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-          )
-        );
-        $context = $context  = stream_context_create($opts);
-        $result = @file_get_contents($url, false, $context);
-        if ($result === false) {
-          $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
+        if (!$result_obj) {
+            Logger::Instance()->log($this->id . ": Not a JSon item, parsing it");
+            $result_obj = $this->explode($result);
+            Logger::Instance()->dump($result_obj);
         }
-        $result_obj = json_decode($result, true);
-        break;
+        $access_token = $result_obj['access_token'];
+        $expires_in = $result_obj['expires_in'];
+        if (!$expires_in) {
+            $expires_in = $result_obj['expires'];
+        }
+
+        $expires_at = time() + $expires_in;
+
+        if (!$access_token || (!$this->ignoreExpiresIn && !$expires_in)) {
+            // malformed access token result detected:
+            $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
+        }
+        else {
+            WPOA_Session::set_token($access_token);
+            WPOA_Session::set_expires_in($expires_in);
+            WPOA_Session::set_expires_at($expires_at);
+            return true;
+        }
     }
-    return $result_obj;
-  }
 
-  function getOAuthIdentity() {
-    $result_obj = $this->getRequest($this->urlUser, $this->id . ": Get Identity");
-    $result_obj = $this->getOauthIdentityPostTreatment($result_obj);
-    $oauth_identity = array();
-    $oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-    $oauth_identity = $this->getOAuthIdentityFillArray($result_obj, $oauth_identity);
-    if (!$oauth_identity[WPOA_Session::USER_ID]) {
-      $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
+    private function explode($input) {
+        $output = array();
+
+        $items = explode( '&', $input );
+
+        foreach( $items as $val ){
+            $tmp = explode( '=', $val );
+            $output[ $tmp[0] ] = $tmp[1];
+        }
+
+        return $output;
     }
-    return $oauth_identity;
-  }
+
+    protected function getRequest($url, $message) {
+        Logger::Instance()->log($message . "->" . $url);
+        // here we exchange the access token for the user info...
+        // set the access token param:
+        $access_token = WPOA_Session::get_token();
+        Logger::Instance()->log($message. ": token = " .$access_token);
+        $params = $this->getOAuthIdentityParameters();
+        $url_params = http_build_query($params);
+        // perform the http request:
+        switch ($this->requestMode) {
+            case 'curl':
+                $url = rtrim($url, "?") . "?";
+                $url .= $url_params;
+                $curl = init_curl($url);
+                Logger::Instance()->log($message . ": Bearer $this->useBearer");
+                curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+                if ($this->useBearer === true) {
+                    Logger::Instance()->log($message . ": Using Bearer");
+                    curl_setopt($curl, CURLOPT_URL, $url);
+                    curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // TODO: does Windows Live require this?
+                    $header = array("Authorization: Bearer " . $access_token, 
+                            "x-li-format: json");
+                    curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
+                }
 
 
-  abstract function getOAuthCodeExtendArray($array);
-  abstract function getOAuthIdentityParameters();
-  abstract function getOAuthIdentityFillArray($result_obj, $oauth_identity);
-  
-  function getOAuthTokenExtendArray($array) {
-    return $array;
-  }
-  function getOauthIdentityPostTreatment($result_obj) {
-    return $result_obj;
-  }
+                $result = exec_curl($curl, "get oauth identity");
+                $result_obj = json_decode($result, true);
+                break;
+            case 'stream-context':
+                $url = rtrim($url, "?");
+                $opts = array('http' =>
+                        array(
+                            'method'  => 'GET',
+                            // PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
+                            'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
+                            )
+                        );
+                $context = $context  = stream_context_create($opts);
+                $result = @file_get_contents($url, false, $context);
+                if ($result === false) {
+                    $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
+                }
+                $result_obj = json_decode($result, true);
+                break;
+        }
+        return $result_obj;
+    }
+
+    function getOAuthIdentity() {
+        $result_obj = $this->getRequest($this->urlUser, $this->id . ": Get Identity");
+        $result_obj = $this->getOauthIdentityPostTreatment($result_obj);
+        $oauth_identity = array();
+        $oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+        $oauth_identity = $this->getOAuthIdentityFillArray($result_obj, $oauth_identity);
+        if (!$oauth_identity[WPOA_Session::USER_ID]) {
+            $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
+        }
+        return $oauth_identity;
+    }
+
+
+    abstract function getOAuthCodeExtendArray($array);
+    abstract function getOAuthIdentityParameters();
+    abstract function getOAuthIdentityFillArray($result_obj, $oauth_identity);
+
+    function getOAuthTokenExtendArray($array) {
+        return $array;
+    }
+    function getOauthIdentityPostTreatment($result_obj) {
+        return $result_obj;
+    }
 }

--- a/login-common.php
+++ b/login-common.php
@@ -4,242 +4,263 @@ require_once "logger.php";
 error_reporting(E_ALL | E_STRICT);
 
 function init_curl($url) {
-	Logger::Instance()->log("CURL : Init with url = " . $url);
-	$curl = curl_init($url);
-	$verify_ssl= get_option('wpoa_http_util_verify_ssl');
-	curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, ($verify_ssl == 1 ? 1 : 0));
-	curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, ($verify_ssl == 1 ? 2 : 0));
-	curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-	return $curl;
+  Logger::Instance()->log("CURL : Init with url = " . $url);
+  $curl = curl_init($url);
+  $verify_ssl= get_option('wpoa_http_util_verify_ssl');
+  curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, ($verify_ssl == 1 ? 1 : 0));
+  curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, ($verify_ssl == 1 ? 2 : 0));
+  curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+  return $curl;
 }
 
 
 function exec_curl($curl, $message = "") {
-	$result = curl_exec($curl);
+  $result = curl_exec($curl);
 
-	if(!$result) {
-		$error = curl_error($curl);
-		Logger::Instance()->log("CURL : error : " . $message);
-		trigger_error($error);
-	}
-	
-	curl_close($curl);
-	Logger::Instance()->log("CURL : exec reult = " . $result);
-	return $result;
-	
+  if(!$result) {
+    $error = curl_error($curl);
+    Logger::Instance()->log("CURL : error : " . $message);
+    trigger_error($error);
+  }
+  
+  curl_close($curl);
+  Logger::Instance()->log("CURL : exec reult = " . $result);
+  return $result;
+  
 }
 
 abstract class AbstractLoginCommon {
-	private $id;
-	private $name;
-	private $wpoa;
-	
-	private $urlAuth;
-	private $urlToken;
-	private $urlUser;
-	
-	
-	private $clientEnabled;
-	private $clientId;
-	private $clientSecret;
-	// 	define('TENANT_ID', get_option('wpoa_windowsazure_tenant_id'));
-	private $redirectUri;
+  private $id;
+  private $name;
+  private $wpoa;
+  
+  private $urlAuth;
+  private $urlToken;
+  private $urlUser;
+  
+  
+  private $clientEnabled;
+  private $clientId;
+  private $clientSecret;
+  //   define('TENANT_ID', get_option('wpoa_windowsazure_tenant_id'));
+  private $redirectUri;
 
-	private $requestMode;
-	
-	protected $useBearer;
-	// 	define('SCOPE', 'https%3A%2F%2Fgraph.microsoft.com%2Fmail.read');
-	
-	protected function __construct($name, $urlAuth, $urlToken, $urlUser, $wpoa) {
-		$this->id = $this->clean($name);
-		$this->name = $name;
-		$this->wpoa = $wpoa;
-		
-		$this->urlAuth = $urlAuth;
-		$this->urlToken = $urlToken;
-		$this->urlUser = $urlUser;
-		$base = "wpoa_" . $this->id;
-		$this->clientEnabled = get_option($base . '_api_enabled');
-		$this->clientId = get_option($base . '_api_id');
-		$this->clientSecret = get_option($base . '_api_secret');
+  private $requestMode;
+  
+  protected $useBearer;
+  //   define('SCOPE', 'https%3A%2F%2Fgraph.microsoft.com%2Fmail.read');
+  
+  protected function __construct($name, $urlAuth, $urlToken, $urlUser, $wpoa) {
+    $this->id = $this->clean($name);
+    $this->name = $name;
+    $this->wpoa = $wpoa;
+    
+    $this->urlAuth = $urlAuth;
+    $this->urlToken = $urlToken;
+    $this->urlUser = $urlUser;
+    $base = "wpoa_" . $this->id;
+    $this->clientEnabled = get_option($base . '_api_enabled');
+    $this->clientId = get_option($base . '_api_id');
+    $this->clientSecret = get_option($base . '_api_secret');
 
-		Logger::Instance()->log("CONSTRUCT STATE : enabled = $this->clientEnabled / id = $this->clientId / secret = $this->clientSecret");
-		
-		$this->redirectUri = rtrim(site_url(), '/') . '/';
-		$this->requestMode = strtolower(get_option('wpoa_http_util'));
-	}
-	
-	private function clean($value) {
-		$result = strtolower($value);
-		$result = str_replace(" ", "", $result);
-		$result = str_replace(".", "", $result);
-		return $result;
-	}
-	
-	public function run() {
-		WPOA_Session::save_last_url();
-		WPOA_Session::set_provider($this->name);
-		if (!$this->clientEnabled) {
-			$this->wpoa->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-		}
-		elseif (!$this->clientId || !$this->clientSecret) {
-			$this->wpoa->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-		}
-		elseif (isset($_GET['error_description'])) {
-			$this->wpoa->wpoa_end_login($_GET['error_description']);
-		}
-		elseif (isset($_GET['error_message'])) {
-			$this->wpoa->wpoa_end_login($_GET['error_message']);
-		}
-		elseif (isset($_GET['code'])) {
-			if (WPOA_Session::get_state() == $_GET['state']) {
-				$this->getOAuthToken();
-				// 				get the user's third-party identity and attempt to login/register a matching wordpress user account:
-				$oauth_identity = $this->getOAuthIdentity();
-				$this->wpoa->wpoa_login_user($oauth_identity);
-			}
-			else {
-				// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-				// TODO: report detailed message to admin/logs here...
-				$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-			}
-		}
-		else {
-			// pre-auth, start the auth process:
-			if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-				// expired token; clear the state:
-				$this->wpoa->wpoa_clear_login_state();
-			}
-			$this->getOAuthCode();
-		}
+    Logger::Instance()->log("CONSTRUCT STATE : enabled = $this->clientEnabled / id = $this->clientId / secret = $this->clientSecret");
+    
+    $this->redirectUri = rtrim(site_url(), '/') . '/';
+    $this->requestMode = strtolower(get_option('wpoa_http_util'));
+  }
+  
+  private function clean($value) {
+    $result = strtolower($value);
+    $result = str_replace(" ", "", $result);
+    $result = str_replace(".", "", $result);
+    return $result;
+  }
+  
+  public function run() {
+    WPOA_Session::save_last_url();
+    WPOA_Session::set_provider($this->name);
+    if (!$this->clientEnabled) {
+      $this->wpoa->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
+    }
+    elseif (!$this->clientId || !$this->clientSecret) {
+      $this->wpoa->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
+    }
+    elseif (isset($_GET['error_description'])) {
+      $this->wpoa->wpoa_end_login($_GET['error_description']);
+    }
+    elseif (isset($_GET['error_message'])) {
+      $this->wpoa->wpoa_end_login($_GET['error_message']);
+    }
+    elseif (isset($_GET['code'])) {
+      if (WPOA_Session::get_state() == $_GET['state']) {
+        $this->getOAuthToken();
+        //         get the user's third-party identity and attempt to login/register a matching wordpress user account:
+        $oauth_identity = $this->getOAuthIdentity();
+        $this->wpoa->wpoa_login_user($oauth_identity);
+      }
+      else {
+        // possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
+        // TODO: report detailed message to admin/logs here...
+        $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
+      }
+    }
+    else {
+      // pre-auth, start the auth process:
+      if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
+        // expired token; clear the state:
+        $this->wpoa->wpoa_clear_login_state();
+      }
+      $this->getOAuthCode();
+    }
   }
 
   function getOAuthCode() {
-	Logger::Instance()->log($this->id . ": Get code");
-	$params = array(
-		'response_type' => 'code',
-		'client_id' => $this->clientId,
-		'state' => uniqid('', true),
-		'redirect_uri' => $this->redirectUri,
-	);
-	$params = $this->getOAuthCodeExtendArray($params);
-	Logger::Instance()->dump($params);
-	WPOA_Session::set_state($params['state']);
-	$url = $this->urlAuth . http_build_query($params);
-	Logger::Instance()->log($this->id . ": Get Oauth code from : " . $url);
-	header("Location: $url");
-	exit;
+    Logger::Instance()->log($this->id . ": Get code");
+    $params = array(
+      'response_type' => 'code',
+      'client_id' => $this->clientId,
+      'state' => uniqid('', true),
+      'redirect_uri' => $this->redirectUri,
+    );
+    $params = $this->getOAuthCodeExtendArray($params);
+    Logger::Instance()->dump($params);
+    WPOA_Session::set_state($params['state']);
+    $url = $this->urlAuth . http_build_query($params);
+    Logger::Instance()->log($this->id . ": Get Oauth code from : " . $url);
+    header("Location: $url");
+    exit;
+    }
+  
+    
+    function getOAuthToken() {
+    Logger::Instance()->log($this->id . ": Get Token");
+    $params = array(
+      'grant_type' => 'authorization_code',
+      'client_id' => $this->clientId,
+      'client_secret' => $this->clientSecret,
+      'code' => $_GET['code'],
+      'redirect_uri' => $this->redirectUri,
+    );
+    $params = $this->getOAuthTokenExtendArray($params);
+    $url_params = http_build_query($params);
+    switch ($this->requestMode) {
+      case 'curl':
+        $url = $this->urlToken;
+        $curl = init_curl($url);
+        curl_setopt($curl, CURLOPT_POST, 1);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
+        // PROVIDER NORMALIZATION: PayPal requires Accept and Accept-Language headers, Reddit requires sending a User-Agent header
+        // PROVIDER NORMALIZATION: PayPal/Reddit requires sending the client id/secret via http basic authentication
+        
+        $result = exec_curl($curl, $this->id . " get token");
+        break;
+      case 'stream-context':
+        $url = rtrim($this->urlToken, "?");
+        $opts = array('http' =>
+          array(
+            'method'  => 'POST',
+            'header'  => 'Content-type: application/x-www-form-urlencoded',
+            'content' => $url_params,
+          )
+        );
+        $context = $context  = stream_context_create($opts);
+        $result = @file_get_contents($url, false, $context);
+        if ($result === false) {
+          $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
+        }
+        break;
+    }
+      
+    $result_obj = json_decode($result, true);
+    if (!$result_obj) {
+      Logger::Instance()->log($this->id . ": Not a JSon item, parsing it");
+      $result_obj = $this->explode($result);
+      Logger::Instance()->dump($result_obj);
+    }
+    $access_token = $result_obj['access_token'];
+    $expires_in = $result_obj['expires_in'];
+    if (!$expires_in) {
+      $expires_in = $result_obj['expires'];
+    }
+
+    $expires_at = time() + $expires_in;
+  
+    if (!$access_token || !$expires_in) {
+      // malformed access token result detected:
+      $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
+    }
+    else {
+      WPOA_Session::set_token($access_token);
+      WPOA_Session::set_expires_in($expires_in);
+      WPOA_Session::set_expires_at($expires_at);
+      return true;
+    }
   }
 
-  
-  function getOAuthToken() {
-	Logger::Instance()->log($this->id . ": Get Token");
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => $this->clientId,
-		'client_secret' => $this->clientSecret,
-		'code' => $_GET['code'],
-		'redirect_uri' => $this->redirectUri,
-	);
-	$params = $this->getOAuthTokenExtendArray($params);
-	$url_params = http_build_query($params);
-	switch ($this->requestMode) {
-		case 'curl':
-			$url = $this->urlToken;
-			$curl = init_curl($url);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			// PROVIDER NORMALIZATION: PayPal requires Accept and Accept-Language headers, Reddit requires sending a User-Agent header
-			// PROVIDER NORMALIZATION: PayPal/Reddit requires sending the client id/secret via http basic authentication
-			
-			$result = exec_curl($curl, "google get token");
-			break;
-		case 'stream-context':
-			$url = rtrim($this->urlToken, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
+  private function explode($input) {
+    $output = array();
 
-	$result_obj = json_decode($result, true);
-	$access_token = $result_obj['access_token'];
-	$expires_in = $result_obj['expires_in'];
-	$expires_at = time() + $expires_in;
+    $items = explode( '&', $input );
 
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
+    foreach( $items as $val ){
+        $tmp = explode( '=', $val );
+        $output[ $tmp[0] ] = $tmp[1];
+    }
+
+    return $output;
   }
 
-  
-function getOAuthIdentity() {
-	Logger::Instance()->log($this->id . ": Get Identity");
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$access_token = WPOA_Session::get_token();
-	Logger::Instance()->log($this->id . ": token = " .$access_token);
-	$params = $this->getOAuthIdentityParameters();
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch ($this->requestMode) {
-		case 'curl':
-			$url = $this->urlUser;
-			$url .= $url_params;
-			$curl = init_curl($url);
-			Logger::Instance()->log($this->id . ": Bearer $this->useBearer");
-			if ($this->useBearer === true) {
-				Logger::Instance()->log($this->id . ": Using Bearer");
-				curl_setopt($curl, CURLOPT_URL, $url);
-				curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // TODO: does Windows Live require this?
-				curl_setopt($curl, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $access_token)); // PROVIDER SPECIFIC: do we have to do this for Windows Live?
-			}
-			
-			$result = exec_curl($curl, "get oauth identity");
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim($this->urlUser, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	$result_obj = $this->getOauthIdentityPostTreatment($result_obj);
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity = $this->getOAuthIdentityFillArray($result_obj, $oauth_identity);
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
-	return $oauth_identity;
-}
+  function getOAuthIdentity() {
+    Logger::Instance()->log($this->id . ": Get Identity");
+    // here we exchange the access token for the user info...
+    // set the access token param:
+    $access_token = WPOA_Session::get_token();
+    Logger::Instance()->log($this->id . ": token = " .$access_token);
+    $params = $this->getOAuthIdentityParameters();
+    $url_params = http_build_query($params);
+    // perform the http request:
+    switch ($this->requestMode) {
+      case 'curl':
+        $url = $this->urlUser;
+        $url .= $url_params;
+        $curl = init_curl($url);
+        Logger::Instance()->log($this->id . ": Bearer $this->useBearer");
+        if ($this->useBearer === true) {
+          Logger::Instance()->log($this->id . ": Using Bearer");
+          curl_setopt($curl, CURLOPT_URL, $url);
+          curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // TODO: does Windows Live require this?
+          curl_setopt($curl, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $access_token)); // PROVIDER SPECIFIC: do we have to do this for Windows Live?
+        }
+        
+        $result = exec_curl($curl, "get oauth identity");
+        $result_obj = json_decode($result, true);
+        break;
+      case 'stream-context':
+        $url = rtrim($this->urlUser, "?");
+        $opts = array('http' =>
+          array(
+            'method'  => 'GET',
+            // PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
+            'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
+          )
+        );
+        $context = $context  = stream_context_create($opts);
+        $result = @file_get_contents($url, false, $context);
+        if ($result === false) {
+          $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
+        }
+        $result_obj = json_decode($result, true);
+        break;
+    }
+    $result_obj = $this->getOauthIdentityPostTreatment($result_obj);
+    $oauth_identity = array();
+    $oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+    $oauth_identity = $this->getOAuthIdentityFillArray($result_obj, $oauth_identity);
+    if (!$oauth_identity[WPOA_Session::USER_ID]) {
+      $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
+    }
+    return $oauth_identity;
+  }
 
 
   abstract function getOAuthCodeExtendArray($array);
@@ -247,9 +268,9 @@ function getOAuthIdentity() {
   abstract function getOAuthIdentityFillArray($result_obj, $oauth_identity);
   
   function getOAuthTokenExtendArray($array) {
-	  return $array;
+    return $array;
   }
   function getOauthIdentityPostTreatment($result_obj) {
-	  return $result_obj;
+    return $result_obj;
   }
 }

--- a/login-common.php
+++ b/login-common.php
@@ -279,6 +279,8 @@ abstract class AbstractLoginCommon {
 
     private function getOAuthIdentity() {
         $result_obj = $this->getRequest($this->urlUser, $this->id . ": Get Identity");
+	Logger::Instance()->log("Answer array : ");
+	Logger::Instance()->dump($result_obj);
         $result_obj = $this->getOauthIdentityPostTreatment($result_obj);
         $oauth_identity = array();
         $oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();

--- a/login-common.php
+++ b/login-common.php
@@ -1,0 +1,26 @@
+<?php
+include_once "logger.php";
+
+function init_curl($url) {
+	$logger->log("CURL : Init with url = " . $url);
+	$curl = curl_init($url);
+	$verify_ssl= get_option('wpoa_http_util_verify_ssl');
+	curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, ($verify_ssl == 1 ? 1 : 0));
+	curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, ($verify_ssl == 1 ? 2 : 0));
+	curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+			
+	return $curl;
+}
+
+function exec_curl($curl, $message = "") {
+    $result = curl_exec($curl);
+
+    if(!$result) { 
+      curl_error($curl);
+      $logger->log("CURL : error : " . $message);
+      trigger_error($error); 
+    }
+    curl_close($curl);
+    $logger->log("CURL : exec reult = " . $result);
+    return $result;
+}

--- a/login-common.php
+++ b/login-common.php
@@ -1,5 +1,7 @@
 <?php
-include_once "logger.php";
+require_once "logger.php";
+
+error_reporting(E_ALL | E_STRICT);
 
 function init_curl($url) {
 	Logger::Instance()->log("CURL : Init with url = " . $url);
@@ -8,19 +10,246 @@ function init_curl($url) {
 	curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, ($verify_ssl == 1 ? 1 : 0));
 	curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, ($verify_ssl == 1 ? 2 : 0));
 	curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			
 	return $curl;
 }
 
-function exec_curl($curl, $message = "") {
-    $result = curl_exec($curl);
 
-    if(!$result) { 
-      curl_error($curl);
-      Logger::Instance()->log("CURL : error : " . $message);
-      trigger_error($error); 
-    }
-    curl_close($curl);
-    Logger::Instance()->log("CURL : exec reult = " . $result);
-    return $result;
+function exec_curl($curl, $message = "") {
+	$result = curl_exec($curl);
+
+	if(!$result) {
+		$error = curl_error($curl);
+		Logger::Instance()->log("CURL : error : " . $message);
+		trigger_error($error);
+	}
+	
+	curl_close($curl);
+	Logger::Instance()->log("CURL : exec reult = " . $result);
+	return $result;
+	
+}
+
+abstract class AbstractLoginCommon {
+	private $id;
+	private $name;
+	private $wpoa;
+	
+	private $urlAuth;
+	private $urlToken;
+	private $urlUser;
+	
+	
+	private $clientEnabled;
+	private $clientId;
+	private $clientSecret;
+	// 	define('TENANT_ID', get_option('wpoa_windowsazure_tenant_id'));
+	private $redirectUri;
+
+	private $requestMode;
+	
+	protected $useBearer;
+	// 	define('SCOPE', 'https%3A%2F%2Fgraph.microsoft.com%2Fmail.read');
+	
+	protected function __construct($name, $urlAuth, $urlToken, $urlUser, $wpoa) {
+		$this->id = $this->clean($name);
+		$this->name = $name;
+		$this->wpoa = $wpoa;
+		
+		$this->urlAuth = $urlAuth;
+		$this->urlToken = $urlToken;
+		$this->urlUser = $urlUser;
+		$base = "wpoa_" . $this->id;
+		$this->clientEnabled = get_option($base . '_api_enabled');
+		$this->clientId = get_option($base . '_api_id');
+		$this->clientSecret = get_option($base . '_api_secret');
+
+		Logger::Instance()->log("CONSTRUCT STATE : enabled = $this->clientEnabled / id = $this->clientId / secret = $this->clientSecret");
+		
+		$this->redirectUri = rtrim(site_url(), '/') . '/';
+		$this->requestMode = strtolower(get_option('wpoa_http_util'));
+	}
+	
+	private function clean($value) {
+		$result = strtolower($value);
+		$result = str_replace(" ", "", $result);
+		$result = str_replace(".", "", $result);
+		return $result;
+	}
+	
+	public function run() {
+		WPOA_Session::save_last_url();
+		WPOA_Session::set_provider($this->name);
+		if (!$this->clientEnabled) {
+			$this->wpoa->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
+		}
+		elseif (!$this->clientId || !$this->clientSecret) {
+			$this->wpoa->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
+		}
+		elseif (isset($_GET['error_description'])) {
+			$this->wpoa->wpoa_end_login($_GET['error_description']);
+		}
+		elseif (isset($_GET['error_message'])) {
+			$this->wpoa->wpoa_end_login($_GET['error_message']);
+		}
+		elseif (isset($_GET['code'])) {
+			if (WPOA_Session::get_state() == $_GET['state']) {
+				$this->getOAuthToken();
+				// 				get the user's third-party identity and attempt to login/register a matching wordpress user account:
+				$oauth_identity = $this->getOAuthIdentity();
+				$this->wpoa->wpoa_login_user($oauth_identity);
+			}
+			else {
+				// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
+				// TODO: report detailed message to admin/logs here...
+				$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
+			}
+		}
+		else {
+			// pre-auth, start the auth process:
+			if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
+				// expired token; clear the state:
+				$this->wpoa->wpoa_clear_login_state();
+			}
+			$this->getOAuthCode();
+		}
+  }
+
+  function getOAuthCode() {
+	Logger::Instance()->log($this->id . ": Get code");
+	$params = array(
+		'response_type' => 'code',
+		'client_id' => $this->clientId,
+		'state' => uniqid('', true),
+		'redirect_uri' => $this->redirectUri,
+	);
+	$params = $this->getOAuthCodeExtendArray($params);
+	Logger::Instance()->dump($params);
+	WPOA_Session::set_state($params['state']);
+	$url = $this->urlAuth . http_build_query($params);
+	Logger::Instance()->log($this->id . ": Get Oauth code from : " . $url);
+	header("Location: $url");
+	exit;
+  }
+
+  
+  function getOAuthToken() {
+	Logger::Instance()->log($this->id . ": Get Token");
+	$params = array(
+		'grant_type' => 'authorization_code',
+		'client_id' => $this->clientId,
+		'client_secret' => $this->clientSecret,
+		'code' => $_GET['code'],
+		'redirect_uri' => $this->redirectUri,
+	);
+	$params = $this->getOAuthTokenExtendArray($params);
+	$url_params = http_build_query($params);
+	switch ($this->requestMode) {
+		case 'curl':
+			$url = $this->urlToken;
+			$curl = init_curl($url);
+			curl_setopt($curl, CURLOPT_POST, 1);
+			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
+			// PROVIDER NORMALIZATION: PayPal requires Accept and Accept-Language headers, Reddit requires sending a User-Agent header
+			// PROVIDER NORMALIZATION: PayPal/Reddit requires sending the client id/secret via http basic authentication
+			
+			$result = exec_curl($curl, "google get token");
+			break;
+		case 'stream-context':
+			$url = rtrim($this->urlToken, "?");
+			$opts = array('http' =>
+				array(
+					'method'  => 'POST',
+					'header'  => 'Content-type: application/x-www-form-urlencoded',
+					'content' => $url_params,
+				)
+			);
+			$context = $context  = stream_context_create($opts);
+			$result = @file_get_contents($url, false, $context);
+			if ($result === false) {
+				$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
+			}
+			break;
+	}
+
+	$result_obj = json_decode($result, true);
+	$access_token = $result_obj['access_token'];
+	$expires_in = $result_obj['expires_in'];
+	$expires_at = time() + $expires_in;
+
+	if (!$access_token || !$expires_in) {
+		// malformed access token result detected:
+		$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
+	}
+	else {
+		WPOA_Session::set_token($access_token);
+		WPOA_Session::set_expires_in($expires_in);
+		WPOA_Session::set_expires_at($expires_at);
+		return true;
+	}
+  }
+
+  
+function getOAuthIdentity() {
+	Logger::Instance()->log($this->id . ": Get Identity");
+	// here we exchange the access token for the user info...
+	// set the access token param:
+	$access_token = WPOA_Session::get_token();
+	Logger::Instance()->log($this->id . ": token = " .$access_token);
+	$params = $this->getOAuthIdentityParameters();
+	$url_params = http_build_query($params);
+	// perform the http request:
+	switch ($this->requestMode) {
+		case 'curl':
+			$url = $this->urlUser;
+			$url .= $url_params;
+			$curl = init_curl($url);
+			Logger::Instance()->log($this->id . ": Bearer $this->useBearer");
+			if ($this->useBearer === true) {
+				Logger::Instance()->log($this->id . ": Using Bearer");
+				curl_setopt($curl, CURLOPT_URL, $url);
+				curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // TODO: does Windows Live require this?
+				curl_setopt($curl, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $access_token)); // PROVIDER SPECIFIC: do we have to do this for Windows Live?
+			}
+			
+			$result = exec_curl($curl, "get oauth identity");
+			$result_obj = json_decode($result, true);
+			break;
+		case 'stream-context':
+			$url = rtrim($this->urlUser, "?");
+			$opts = array('http' =>
+				array(
+					'method'  => 'GET',
+					// PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
+					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
+				)
+			);
+			$context = $context  = stream_context_create($opts);
+			$result = @file_get_contents($url, false, $context);
+			if ($result === false) {
+				$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
+			}
+			$result_obj = json_decode($result, true);
+			break;
+	}
+	$result_obj = $this->getOauthIdentityPostTreatment($result_obj);
+	$oauth_identity = array();
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity = $this->getOAuthIdentityFillArray($result_obj, $oauth_identity);
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
+		$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
+	}
+	return $oauth_identity;
+}
+
+
+  abstract function getOAuthCodeExtendArray($array);
+  abstract function getOAuthIdentityParameters();
+  abstract function getOAuthIdentityFillArray($result_obj, $oauth_identity);
+  
+  function getOAuthTokenExtendArray($array) {
+	  return $array;
+  }
+  function getOauthIdentityPostTreatment($result_obj) {
+	  return $result_obj;
+  }
 }

--- a/login-facebook.php
+++ b/login-facebook.php
@@ -3,41 +3,36 @@
 include_once 'session.php';
 include_once 'login-common.php';
 
-
 error_reporting(E_ALL | E_STRICT);
 
 class LoginFacebook extends AbstractLoginCommon {
-	public function __construct($wpoa) {
-		parent::__construct('Facebook', 
-			"https://www.facebook.com/dialog/oauth?", 
-			"https://graph.facebook.com/oauth/access_token?", 
-			"https://graph.facebook.com/me?",
-			$wpoa);
-	}
-
-	
-  function getOAuthCodeExtendArray($array){
-	  $array['scope'] = 'email';
-	  return $array;
+  public function __construct($wpoa) {
+    parent::__construct('Facebook', 
+      "https://www.facebook.com/dialog/oauth?", 
+      "https://graph.facebook.com/oauth/access_token?", 
+      "https://graph.facebook.com/me?",
+      $wpoa);
   }
   
-  function getOAuthIdentityParameters(){
-	$params = array(
-		'access_token' => WPOA_Session::get_token(),
-		'fields' => "id,name,email"
-	);
-	return $params;
+  function getOAuthCodeExtendArray($array) {
+    $array['scope'] = 'email';
+    return $array;
   }
   
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
-	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
-	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
-
-	return $oauth_identity;
+  function getOAuthIdentityParameters() {
+    return array(
+      'access_token' => WPOA_Session::get_token(),
+      'fields' => "id,name,email"
+    );
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity) {
+    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+    $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+    return $oauth_identity;
   }
 }
-
 
 $login = new LoginFacebook($this);
 $login->run();

--- a/login-facebook.php
+++ b/login-facebook.php
@@ -1,12 +1,9 @@
 <?php
 
-// start the user session for maintaining individual user states during the multi-stage authentication flow:
-if (!isset($_SESSION)) {
-    session_start();
-}
+include_once 'session.php';
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-$_SESSION['WPOA']['PROVIDER'] = 'Facebook';
+WPOA_Session::set_provider('Facebook');
 define('HTTP_UTIL', get_option('wpoa_http_util'));
 define('CLIENT_ENABLED', get_option('wpoa_facebook_api_enabled'));
 define('CLIENT_ID', get_option('wpoa_facebook_api_id'));
@@ -18,8 +15,7 @@ define('URL_TOKEN', "https://graph.facebook.com/oauth/access_token?");
 define('URL_USER', "https://graph.facebook.com/me?");
 # END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-// remember the user's last url so we can redirect them back to there after the login ends:
-if (!$_SESSION['WPOA']['LAST_URL']) {$_SESSION['WPOA']['LAST_URL'] = strtok($_SERVER['HTTP_REFERER'], "?");}
+WPOA_Session::save_last_url();
 
 # AUTHENTICATION FLOW #
 // the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
@@ -40,7 +36,7 @@ elseif (isset($_GET['error_message'])) {
 }
 elseif (isset($_GET['code'])) {
 	// post-auth phase, verify the state:
-	if ($_SESSION['WPOA']['STATE'] == $_GET['state']) {
+	if (WPOA_Session::get_state() == $_GET['state']) {
 		// get an access token from the third party provider:
 		get_oauth_token($this);
 		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
@@ -55,7 +51,7 @@ elseif (isset($_GET['code'])) {
 }
 else {
 	// pre-auth, start the auth process:
-	if ((empty($_SESSION['WPOA']['EXPIRES_AT'])) || (time() > $_SESSION['WPOA']['EXPIRES_AT'])) {
+	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
 		// expired token; clear the state:
 		$this->wpoa_clear_login_state();
 	}
@@ -74,7 +70,7 @@ function get_oauth_code($wpoa) {
 		'state' => uniqid('', true),
 		'redirect_uri' => REDIRECT_URI,
 	);
-	$_SESSION['WPOA']['STATE'] = $params['state'];
+	WPOA_Session::set_state($params['state']);
 	$url = URL_AUTH . http_build_query($params);
 	header("Location: $url");
 	exit;
@@ -130,9 +126,9 @@ function get_oauth_token($wpoa) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
 	}
 	else {
-		$_SESSION['WPOA']['ACCESS_TOKEN'] = $access_token;
-		$_SESSION['WPOA']['EXPIRES_IN'] = $expires_in;
-		$_SESSION['WPOA']['EXPIRES_AT'] = $expires_at;
+		WPOA_Session::set_token($access_token);
+		WPOA_Session::set_expires_in($expires_in);
+		WPOA_Session::set_expires_at($expires_at);
 		return true;
 	}
 }
@@ -141,7 +137,7 @@ function get_oauth_identity($wpoa) {
 	// here we exchange the access token for the user info...
 	// set the access token param:
 	$params = array(
-		'access_token' => $_SESSION['WPOA']['ACCESS_TOKEN'], // PROVIDER SPECIFIC: the access token is passed to Facebook using this key name
+		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to Facebook using this key name
 	);
 	$url_params = http_build_query($params);
 	// perform the http request:
@@ -163,7 +159,7 @@ function get_oauth_identity($wpoa) {
 				array(
 					'method'  => 'GET',
 					// PROVIDER NORMALIZATION: Reddit/Github User-Agent
-					'header'  => "Authorization: Bearer " . $_SESSION['WPOA']['ACCESS_TOKEN'] . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
+					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
 				)
 			);
 			$context = $context  = stream_context_create($opts);
@@ -176,7 +172,7 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = $_SESSION['WPOA']['PROVIDER'];
+	$oauth_identity['provider'] = WPOA_Session::get_provider();
 	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Facebook returns the user's unique id
 	//$oauth_identity['email'] = $result_obj['email']; //PROVIDER SPECIFIC: this is how Facebook returns the email address
 	if (!$oauth_identity['id']) {

--- a/login-facebook.php
+++ b/login-facebook.php
@@ -6,32 +6,32 @@ include_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginFacebook extends AbstractLoginCommon {
-  public function __construct($wpoa) {
-    parent::__construct('Facebook', 
-      "https://www.facebook.com/dialog/oauth?", 
-      "https://graph.facebook.com/oauth/access_token?", 
-      "https://graph.facebook.com/me?",
-      $wpoa);
-  }
-  
-  function getOAuthCodeExtendArray($array) {
-    $array['scope'] = 'email';
-    return $array;
-  }
-  
-  function getOAuthIdentityParameters() {
-    return array(
-      'access_token' => WPOA_Session::get_token(),
-      'fields' => "id,name,email"
-    );
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity) {
-    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
-    $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
-    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
-    return $oauth_identity;
-  }
+    public function __construct($wpoa) {
+        parent::__construct('Facebook',
+                "https://www.facebook.com/dialog/oauth?",
+                "https://graph.facebook.com/oauth/access_token?",
+                "https://graph.facebook.com/me?",
+                $wpoa);
+    }
+
+    function getOAuthCodeExtendArray($array) {
+        $array['scope'] = 'email';
+        return $array;
+    }
+
+    function getOAuthIdentityParameters() {
+        return array(
+                'access_token' => WPOA_Session::get_token(),
+                'fields' => "id,name,email"
+                );
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity) {
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+        return $oauth_identity;
+    }
 }
 
 $login = new LoginFacebook($this);

--- a/login-facebook.php
+++ b/login-facebook.php
@@ -3,183 +3,41 @@
 include_once 'session.php';
 include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('Facebook');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_facebook_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_facebook_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_facebook_api_secret'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'public_profile,email'); // PROVIDER SPECIFIC: 'email' is the minimum scope required to get the user's id from Facebook
-define('URL_AUTH', "https://www.facebook.com/dialog/oauth?");
-define('URL_TOKEN', "https://graph.facebook.com/oauth/access_token?");
-define('URL_USER', "https://graph.facebook.com/me?");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-WPOA_Session::save_last_url();
+error_reporting(E_ALL | E_STRICT);
 
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
+class LoginFacebook extends AbstractLoginCommon {
+	public function __construct($wpoa) {
+		parent::__construct('Facebook', 
+			"https://www.facebook.com/dialog/oauth?", 
+			"https://graph.facebook.com/oauth/access_token?", 
+			"https://graph.facebook.com/me?",
+			$wpoa);
 	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
+	
+  function getOAuthCodeExtendArray($array){
+	  $array['scope'] = 'email';
+	  return $array;
+  }
+  
+  function getOAuthIdentityParameters(){
 	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
-}
-
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = init_curl($url);
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			// PROVIDER NORMALIZATION: Reddit requires sending a User-Agent header...
-			// PROVIDER NORMALIZATION: Reddit requires sending the client id/secret via http basic authentication
-			$result = exec_curl($curl);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_TOKEN, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	parse_str($result, $result_obj); // PROVIDER SPECIFIC: Facebook encodes the access token result as a querystring by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Facebook returns the access token KEEP THIS PROTECTED!
-	$expires_in = $result_obj['expires']; // PROVIDER SPECIFIC: this is how Facebook returns the access token's expiration
-	$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
-}
-
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to Facebook using this key name
+		'access_token' => WPOA_Session::get_token(),
 		'fields' => "id,name,email"
 	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_USER . $url_params; // TODO: we probably want to send this using a curl_setopt...
-			$curl = init_curl($url);
-			curl_setopt($curl, CURLOPT_URL, $url);
-			// PROVIDER NORMALIZATION: Reddit/Github requires a User-Agent here...
-			// PROVIDER NORMALIZATION: Reddit requires that we send the access token via a bearer header...
-			//curl_setopt($curl, CURLOPT_HTTPHEADER, array('x-li-format: json')); // PROVIDER SPECIFIC: I think this is only for LinkedIn...
-			$result = exec_curl($curl);
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github User-Agent
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	Logger::Instance()->log("FACEBOOK LOG");
-	Logger::Instance()->dump($result_obj);
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Facebook returns the user's unique id
-	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name']; // PROVIDER SPECIFIC: this is how Facebook returns the user's unique id
-	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email']; //PROVIDER SPECIFIC: this is how Facebook returns the email address
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
+	return $params;
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+
 	return $oauth_identity;
+  }
 }
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
+
+
+$login = new LoginFacebook($this);
+$login->run();

--- a/login-facebook.php
+++ b/login-facebook.php
@@ -172,10 +172,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Facebook returns the user's unique id
-	//$oauth_identity['email'] = $result_obj['email']; //PROVIDER SPECIFIC: this is how Facebook returns the email address
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Facebook returns the user's unique id
+	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['email']; //PROVIDER SPECIFIC: this is how Facebook returns the email address
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-github.php
+++ b/login-github.php
@@ -1,9 +1,7 @@
 <?php
 
-
 include_once 'session.php';
 include_once 'login-common.php';
-
 
 error_reporting(E_ALL | E_STRICT);
 
@@ -14,9 +12,8 @@ class LoginLinkedin extends AbstractLoginCommon {
       "https://github.com/login/oauth/access_token", 
       "https://api.github.com/user",
       $wpoa);
-	  $this->ignoreExpiresIn = true;
+      $this->ignoreExpiresIn = true;
   }
-
   
   function getOAuthCodeExtendArray($array){
     $array['scope'] = 'user:email';
@@ -24,78 +21,27 @@ class LoginLinkedin extends AbstractLoginCommon {
   }
   
   function getOAuthIdentityParameters(){
-  return array(
-	  'access_token' => WPOA_Session::get_token()
-	  );
+    return array(
+      'access_token' => WPOA_Session::get_token()
+      );
   }
   
   function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-  $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
-  $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
-  $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+    $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
 
-  return $oauth_identity;
+    return $oauth_identity;
   }
 
   function getOauthIdentityPostTreatment($result_obj) {
-	  $url = $this->getUrlUser() . "/emails";
-	  $emails = $this->getRequest($url , $this->id . ": Get Email");
-	  Logger::Instance()->dump($email);
-	  $result_obj['email'] = $emails[0]['email'];
-	  return $result_obj;
+      $url = $this->getUrlUser() . "/emails";
+      $emails = $this->getRequest($url , $this->id . ": Get Email");
+      Logger::Instance()->dump($email);
+      $result_obj['email'] = $emails[0]['email'];
+      return $result_obj;
   }
 }
 
-
 $login = new LoginLinkedin($this);
 $login->run();
-
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to Github using this key name
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_USER . $url_params; // TODO: we probably want to send this using a curl_setopt...
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // PROVIDER SPECIFIC: Github requires the useragent for all api requests
-			// PROVIDER NORMALIZATION: Reddit requires that we send the access token via a bearer header...
-			//curl_setopt($curl, CURLOPT_HTTPHEADER, array('x-li-format: json')); // PROVIDER SPECIFIC: I think this is only for LinkedIn...
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			$result = curl_exec($curl);
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method' => 'GET',
-					'user_agent' => $_SERVER['HTTP_USER_AGENT'], // PROVIDER NOTE: Github requires the useragent for all api requests
-					'header'  => "Authorization: token " . WPOA_Session::get_token(),
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Github returns the user's unique id
-	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['email']; //PROVIDER SPECIFIC: this is how Github returns the email address
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
-	return $oauth_identity;
-}
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>

--- a/login-github.php
+++ b/login-github.php
@@ -173,10 +173,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Github returns the user's unique id
-	//$oauth_identity['email'] = $result_obj['email']; //PROVIDER SPECIFIC: this is how Github returns the email address
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Github returns the user's unique id
+	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['email']; //PROVIDER SPECIFIC: this is how Github returns the email address
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-github.php
+++ b/login-github.php
@@ -1,138 +1,54 @@
 <?php
 
+
 include_once 'session.php';
+include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('Github');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_github_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_github_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_github_api_secret'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'user'); // PROVIDER SPECIFIC: "user" is the minimum scope required to get the user's id from Github
-define('URL_AUTH', "https://github.com/login/oauth/authorize?");
-define('URL_TOKEN', "https://github.com/login/oauth/access_token?");
-define('URL_USER', "https://api.github.com/user?");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-// remember the user's last url so we can redirect them back to there after the login ends:
-WPOA_Session::save_last_url();
+error_reporting(E_ALL | E_STRICT);
 
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
-	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
+class LoginLinkedin extends AbstractLoginCommon {
+  public function __construct($wpoa) {
+    parent::__construct('Github', 
+      "https://github.com/login/oauth/authorize?", 
+      "https://github.com/login/oauth/access_token", 
+      "https://api.github.com/user",
+      $wpoa);
+	  $this->ignoreExpiresIn = true;
+  }
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
-	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
+  
+  function getOAuthCodeExtendArray($array){
+    $array['scope'] = 'user:email';
+    return $array;
+  }
+  
+  function getOAuthIdentityParameters(){
+  return array(
+	  'access_token' => WPOA_Session::get_token()
+	  );
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+  $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+  $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+  $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+
+  return $oauth_identity;
+  }
+
+  function getOauthIdentityPostTreatment($result_obj) {
+	  $url = $this->getUrlUser() . "/emails";
+	  $emails = $this->getRequest($url , $this->id . ": Get Email");
+	  Logger::Instance()->dump($email);
+	  $result_obj['email'] = $emails[0]['email'];
+	  return $result_obj;
+  }
 }
 
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			// PROVIDER NORMALIZATION: Reddit requires sending a User-Agent header...
-			// PROVIDER NORMALIZATION: Reddit requires sending the client id/secret via http basic authentication
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, (get_option('wpoa_http_util_verify_ssl') == 1 ? 1 : 0));
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, (get_option('wpoa_http_util_verify_ssl') == 1 ? 2 : 0));
-			$result = curl_exec($curl);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_TOKEN, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	parse_str($result, $result_obj); // PROVIDER SPECIFIC: Github encodes the access token result as a querystring by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Github returns the access token KEEP THIS PROTECTED!
-	//$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: Github does not return an access token expiration!
-	//$expires_at = time() + $expires_in; // PROVIDER SPECIFIC: Github does not return an access token expiration!
-	// handle the result:
-	if (!$access_token) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		//WPOA_Session::get_expires_in() = $expires_in; // PROVIDER SPECIFIC: Github does not return an access token expiration!
-		//WPOA_Session::get_expires_at() = $expires_at; // PROVIDER SPECIFIC: Github does not return an access token expiration!
-		return true;
-	}
-}
+
+$login = new LoginLinkedin($this);
+$login->run();
 
 function get_oauth_identity($wpoa) {
 	// here we exchange the access token for the user info...

--- a/login-github.php
+++ b/login-github.php
@@ -6,41 +6,41 @@ include_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginLinkedin extends AbstractLoginCommon {
-  public function __construct($wpoa) {
-    parent::__construct('Github', 
-      "https://github.com/login/oauth/authorize?", 
-      "https://github.com/login/oauth/access_token", 
-      "https://api.github.com/user",
-      $wpoa);
-      $this->ignoreExpiresIn = true;
-  }
-  
-  function getOAuthCodeExtendArray($array){
-    $array['scope'] = 'user:email';
-    return $array;
-  }
-  
-  function getOAuthIdentityParameters(){
-    return array(
-      'access_token' => WPOA_Session::get_token()
-      );
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
-    $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
-    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+    public function __construct($wpoa) {
+        parent::__construct('Github',
+                "https://github.com/login/oauth/authorize?",
+                "https://github.com/login/oauth/access_token",
+                "https://api.github.com/user",
+                $wpoa);
+        $this->ignoreExpiresIn = true;
+    }
 
-    return $oauth_identity;
-  }
+    function getOAuthCodeExtendArray($array){
+        $array['scope'] = 'user:email';
+        return $array;
+    }
 
-  function getOauthIdentityPostTreatment($result_obj) {
-      $url = $this->getUrlUser() . "/emails";
-      $emails = $this->getRequest($url , $this->id . ": Get Email");
-      Logger::Instance()->dump($email);
-      $result_obj['email'] = $emails[0]['email'];
-      return $result_obj;
-  }
+    function getOAuthIdentityParameters(){
+        return array(
+                'access_token' => WPOA_Session::get_token()
+                );
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+
+        return $oauth_identity;
+    }
+
+    function getOauthIdentityPostTreatment($result_obj) {
+        $url = $this->getUrlUser() . "/emails";
+        $emails = $this->getRequest($url , $this->id . ": Get Email");
+        Logger::Instance()->dump($email);
+        $result_obj['email'] = $emails[0]['email'];
+        return $result_obj;
+    }
 }
 
 $login = new LoginLinkedin($this);

--- a/login-github.php
+++ b/login-github.php
@@ -20,12 +20,6 @@ class LoginGitHub extends AbstractLoginCommon {
         return $array;
     }
 
-    function getOAuthIdentityParameters(){
-        return array(
-                'access_token' => WPOA_Session::get_token()
-                );
-    }
-
     function getOAuthIdentityFillArray($result_obj, $oauth_identity){
         $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
         $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];

--- a/login-github.php
+++ b/login-github.php
@@ -5,7 +5,7 @@ include_once 'login-common.php';
 
 error_reporting(E_ALL | E_STRICT);
 
-class LoginLinkedin extends AbstractLoginCommon {
+class LoginGitHub extends AbstractLoginCommon {
     public function __construct($wpoa) {
         parent::__construct('Github',
                 "https://github.com/login/oauth/authorize?",
@@ -43,5 +43,5 @@ class LoginLinkedin extends AbstractLoginCommon {
     }
 }
 
-$login = new LoginLinkedin($this);
+$login = new LoginGitHub($this);
 $login->run();

--- a/login-google.php
+++ b/login-google.php
@@ -6,61 +6,61 @@ require_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginGoogle extends AbstractLoginCommon {
-	public function __construct($wpoa) {
-		parent::__construct('Google', 
-			"https://accounts.google.com/o/oauth2/auth?", 
-			"https://accounts.google.com/o/oauth2/token?", 
-			"https://www.googleapis.com/plus/v1/people/me?",
-			$wpoa);
-	}
+    public function __construct($wpoa) {
+        parent::__construct('Google',
+                "https://accounts.google.com/o/oauth2/auth?",
+                "https://accounts.google.com/o/oauth2/token?",
+                "https://www.googleapis.com/plus/v1/people/me?",
+                $wpoa);
+    }
 
-	
-  function getOAuthCodeExtendArray($array){
-	  $array['scope'] = 'email';
-	  return $array;
-  }
-  
-  function getOAuthIdentityParameters(){
-	$params = array(
-		'access_token' => WPOA_Session::get_token(),
-	);
-	return $params;
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
-	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['displayName'];
-	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['emails'][0]['value'];
 
-	return $oauth_identity;
-  }
+    function getOAuthCodeExtendArray($array){
+        $array['scope'] = 'email';
+        return $array;
+    }
 
-   function getOauthIdentityPostTreatment($result_obj) {
-	   return $this->verify_domain($result_obj);
-   }
+    function getOAuthIdentityParameters(){
+        $params = array(
+                'access_token' => WPOA_Session::get_token(),
+                );
+        return $params;
+    }
 
-   function verify_domain($base_result)
-   {
-   	$allowedConfig = get_option('wpoa_google_check_domain');
-   	if (!$allowedConfig) {
-   		return $base_result;
-   	}
-   	
-   	$allowedConfig = str_replace(" ", "", $allowedConfig);
-   	$key = "domain";
-   	$value = "Gmail";
-   	if (array_key_exists($key, $base_result))
-   	{
-   		$value = $base_result[$key]; 
-   		$allowed = explode(",", $allowedConfig);  
-   		if ($value && in_array($value, $allowed))
-   		{
-   			return $base_result;
-   		}
-   	}
-   	$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Your ". $key ." is not allowed : " . $value);
-   	return $null;
-   }
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['displayName'];
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['emails'][0]['value'];
+
+        return $oauth_identity;
+    }
+
+    function getOauthIdentityPostTreatment($result_obj) {
+        return $this->verify_domain($result_obj);
+    }
+
+    function verify_domain($base_result)
+    {
+        $allowedConfig = get_option('wpoa_google_check_domain');
+        if (!$allowedConfig) {
+            return $base_result;
+        }
+
+        $allowedConfig = str_replace(" ", "", $allowedConfig);
+        $key = "domain";
+        $value = "Gmail";
+        if (array_key_exists($key, $base_result))
+        {
+            $value = $base_result[$key];
+            $allowed = explode(",", $allowedConfig);
+            if ($value && in_array($value, $allowed))
+            {
+                return $base_result;
+            }
+        }
+        $this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Your ". $key ." is not allowed : " . $value);
+        return $null;
+    }
 }
 
 

--- a/login-google.php
+++ b/login-google.php
@@ -20,13 +20,6 @@ class LoginGoogle extends AbstractLoginCommon {
         return $array;
     }
 
-    function getOAuthIdentityParameters(){
-        $params = array(
-                'access_token' => WPOA_Session::get_token(),
-                );
-        return $params;
-    }
-
     function getOAuthIdentityFillArray($result_obj, $oauth_identity){
         $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
         $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['displayName'];

--- a/login-google.php
+++ b/login-google.php
@@ -1,206 +1,68 @@
 <?php
 
-include_once 'session.php';
-include_once 'login-common.php';
+require_once 'session.php';
+require_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('Google');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_google_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_google_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_google_api_secret'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'profile'); // PROVIDER SPECIFIC: 'profile' is the minimum scope required to get the user's id from Google
-define('URL_AUTH', "https://accounts.google.com/o/oauth2/auth?");
-define('URL_TOKEN', "https://accounts.google.com/o/oauth2/token?");
-define('URL_USER', "https://www.googleapis.com/plus/v1/people/me?");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
+error_reporting(E_ALL | E_STRICT);
 
-WPOA_Session::save_last_url();
-
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
+class LoginGoogle extends AbstractLoginCommon {
+	public function __construct($wpoa) {
+		parent::__construct('Google', 
+			"https://accounts.google.com/o/oauth2/auth?", 
+			"https://accounts.google.com/o/oauth2/token?", 
+			"https://www.googleapis.com/plus/v1/people/me?",
+			$wpoa);
 	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
+	
+  function getOAuthCodeExtendArray($array){
+	  $array['scope'] = 'email';
+	  return $array;
+  }
+  
+  function getOAuthIdentityParameters(){
 	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-		'scope' => 'email',
+		'access_token' => WPOA_Session::get_token(),
 	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
-}
-
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = init_curl($url);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			// PROVIDER NORMALIZATION: PayPal requires Accept and Accept-Language headers, Reddit requires sending a User-Agent header
-			// PROVIDER NORMALIZATION: PayPal/Reddit requires sending the client id/secret via http basic authentication
-			
-			$result = exec_curl($curl, "google get token");
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_TOKEN, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	$result_obj = json_decode($result, true); // PROVIDER SPECIFIC: Google encodes the access token result as json by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Google returns the access token KEEP THIS PROTECTED!
-	$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: this is how Google returns the access token's expiration
-	$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
-}
-
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access_token is passed to Google via POST param
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_USER . $url_params; // TODO: we probably want to send this using a curl_setopt...
-			$curl = init_curl($url);
-			// PROVIDER NORMALIZATION: Github/Reddit require a User-Agent here...
-			// PROVIDER NORMALIZATION: PayPal/Reddit require that we send the access token via a bearer header, PayPal also requires a Content-Type: application/json header, LinkedIn requires an x-li-format: json header...
-			$result = exec_curl($curl, "google identity");
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	$result_obj = verify_domain($result_obj, $wpoa);
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
+	return $params;
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
 	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['displayName'];
 	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['emails'][0]['value'];
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
+
 	return $oauth_identity;
+  }
+
+   function getOauthIdentityPostTreatment($result_obj) {
+	   return $this->verify_domain($result_obj);
+   }
+
+   function verify_domain($base_result)
+   {
+   	$allowedConfig = get_option('wpoa_google_check_domain');
+   	if (!$allowedConfig) {
+   		return $base_result;
+   	}
+   	
+   	$allowedConfig = str_replace(" ", "", $allowedConfig);
+   	$key = "domain";
+   	$value = "Gmail";
+   	if (array_key_exists($key, $base_result))
+   	{
+   		$value = $base_result[$key]; 
+   		$allowed = explode(",", $allowedConfig);  
+   		if ($value && in_array($value, $allowed))
+   		{
+   			return $base_result;
+   		}
+   	}
+   	$this->wpoa->wpoa_end_login("Sorry, we couldn't log you in. Your ". $key ." is not allowed : " . $value);
+   	return $null;
+   }
 }
 
-function verify_domain($base_result, $wpoa)
-{
-	$allowedConfig = get_option('wpoa_google_check_domain');
-	if (!$allowedConfig) {
-		return $base_result;
-	}
-	
-	$allowedConfig = str_replace(" ", "", $allowedConfig);
-	$key = "domain";
-	$value = "Gmail";
-	if (array_key_exists($key, $base_result))
-	{
-		$value = $base_result[$key]; 
-		$allowed = explode(",", $allowedConfig);  
-		if ($value && in_array($value, $allowed))
-		{
-			return $base_result;
-		}
-	}
-	$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Your ". $key ." is not allowed : " . $value);
-	return $null;
-}
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
 
+$google = new LoginGoogle($this);
+$google->run();

--- a/login-instagram.php
+++ b/login-instagram.php
@@ -1,192 +1,39 @@
 <?php
 
 include_once 'session.php';
+include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('Instagram');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_instagram_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_instagram_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_instagram_api_secret'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'basic'); // PROVIDER SPECIFIC: 'basic' is the minimum scope required to get the user's id from Instagram
-define('URL_AUTH', "https://api.instagram.com/oauth/authorize/?");
-define('URL_TOKEN', "https://api.instagram.com/oauth/access_token?");
-define('URL_USER', "?");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
+error_reporting(E_ALL | E_STRICT);
 
-WPOA_Session::save_last_url();
+class LoginReddit extends AbstractLoginCommon {
+    public function __construct($wpoa) {
+        parent::__construct('Instagram',
+                "https://api.instagram.com/oauth/authorize/?",
+                "https://api.instagram.com/oauth/access_token?",
+                "https://api.instagram.com/v1/users/self/",
+                $wpoa);
+		$this->ignoreExpiresIn = true;
+    }
 
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		$oauth_identity = get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		//$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
-	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
+    function getOAuthCodeExtendArray($array) {
+        $array['scope'] = 'basic';
+        return $array;
+    }
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
-	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
+    function getOAuthIdentityParameters(){
+        return array("access_token" => WPOA_Session::get_token());
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+		$data = $result_obj['data'];
+        $oauth_identity[WPOA_Session::USER_ID] = $data['id'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $data['username'];
+        // TODO : Instagram does not send email. If they implement it, we must update the following line.
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $data['username'] . "@example.com";
+
+        return $oauth_identity;
+    }
 }
 
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			// PROVIDER NORMALIZATION: Reddit requires sending a User-Agent header...
-			// PROVIDER NORMALIZATION: Reddit requires sending the client id/secret via http basic authentication
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, (get_option('wpoa_http_util_verify_ssl') == 1 ? 1 : 0));
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, (get_option('wpoa_http_util_verify_ssl') == 1 ? 2 : 0));
-			$result = curl_exec($curl);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_TOKEN, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	$result_obj = json_decode($result, true); // PROVIDER SPECIFIC: Google encodes the access token result as json by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Google returns the access token KEEP THIS PROTECTED!
-	//$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: this is how Google returns the access token's expiration
-	//$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token) { // PROVIDER SPECIFIC: ...
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		//WPOA_Session::get_expires_in() = $expires_in;
-		//WPOA_Session::get_expires_at() = $expires_at;
-		// parse and return the user's oauth identity:
-		$oauth_identity = array();
-		$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-		$oauth_identity[WPOA_Session::USER_ID] = $result_obj['user']['id']; // PROVIDER SPECIFIC: this is how Google returns the user's unique id
-		//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-		if (!$oauth_identity[WPOA_Session::USER_ID]) {
-			$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-		}
-		return $oauth_identity;
-	}
-}
-
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to Google using this key name
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_USER . $url_params; // TODO: we probably want to send this using a curl_setopt...
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			// PROVIDER NORMALIZATION: Reddit/Github requires a User-Agent here...
-			// PROVIDER NORMALIZATION: Reddit requires that we send the access token via a bearer header...
-			// PROVIDER NORMALIZATION: LinkedIn requires an x-li-format: json header...
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			$result = curl_exec($curl);
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github User-Agent
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Google returns the user's unique id
-	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
-	return $oauth_identity;
-}
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
+$login = new LoginReddit($this);
+$login->run();

--- a/login-instagram.php
+++ b/login-instagram.php
@@ -131,10 +131,10 @@ function get_oauth_token($wpoa) {
 		//WPOA_Session::get_expires_at() = $expires_at;
 		// parse and return the user's oauth identity:
 		$oauth_identity = array();
-		$oauth_identity['provider'] = WPOA_Session::get_provider();
-		$oauth_identity['id'] = $result_obj['user']['id']; // PROVIDER SPECIFIC: this is how Google returns the user's unique id
-		//$oauth_identity['email'] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-		if (!$oauth_identity['id']) {
+		$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+		$oauth_identity[WPOA_Session::USER_ID] = $result_obj['user']['id']; // PROVIDER SPECIFIC: this is how Google returns the user's unique id
+		//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
+		if (!$oauth_identity[WPOA_Session::USER_ID]) {
 			$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 		}
 		return $oauth_identity;
@@ -180,10 +180,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Google returns the user's unique id
-	//$oauth_identity['email'] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Google returns the user's unique id
+	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-itembase.php
+++ b/login-itembase.php
@@ -1,10 +1,9 @@
 <?php
 
-// start the user session for maintaining individual user states during the multi-stage authentication flow:
-session_start();
+include_once 'session.php';
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-$_SESSION['WPOA']['PROVIDER'] = 'itembase';
+WPOA_Session::set_provider('itembase');
 define('HTTP_UTIL', get_option('wpoa_http_util'));
 define('CLIENT_ENABLED', get_option('wpoa_itembase_api_enabled'));
 define('CLIENT_ID', get_option('wpoa_itembase_api_id'));
@@ -16,8 +15,7 @@ define('URL_TOKEN', "https://accounts.itembase.com/oauth/v2/token?");
 define('URL_USER', "https://users.itembase.com/v1/me?");
 # END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-// remember the user's last url so we can redirect them back to there after the login ends:
-if (!$_SESSION['WPOA']['LAST_URL']) {$_SESSION['WPOA']['LAST_URL'] = strtok($_SERVER['HTTP_REFERER'], "?");}
+WPOA_Session::save_last_url();
 
 # AUTHENTICATION FLOW #
 // the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
@@ -38,7 +36,7 @@ elseif (isset($_GET['error_message'])) {
 }
 elseif (isset($_GET['code'])) {
 	// post-auth phase, verify the state:
-	if ($_SESSION['WPOA']['STATE'] == $_GET['state']) {
+	if (WPOA_Session::get_state() == $_GET['state']) {
 		// get an access token from the third party provider:
 		get_oauth_token($this);
 		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
@@ -53,7 +51,7 @@ elseif (isset($_GET['code'])) {
 }
 else {
 	// pre-auth, start the auth process:
-	if ((empty($_SESSION['WPOA']['EXPIRES_AT'])) || (time() > $_SESSION['WPOA']['EXPIRES_AT'])) {
+	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
 		// expired token; clear the state:
 		$this->wpoa_clear_login_state();
 	}
@@ -72,7 +70,7 @@ function get_oauth_code($wpoa) {
 		'state' => uniqid('', true),
 		'redirect_uri' => REDIRECT_URI,
 	);
-	$_SESSION['WPOA']['STATE'] = $params['state'];
+	WPOA_Session::set_state($params['state']);
 	$url = URL_AUTH . http_build_query($params);
 	header("Location: $url");
 	exit;
@@ -126,9 +124,9 @@ function get_oauth_token($wpoa) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
 	}
 	else {
-		$_SESSION['WPOA']['ACCESS_TOKEN'] = $access_token;
-		$_SESSION['WPOA']['EXPIRES_IN'] = $expires_in; // PROVIDER SPECIFIC: Get expiration date from response
-		$_SESSION['WPOA']['EXPIRES_AT'] = $expires_at; // PROVIDER SPECIFIC: Get expiration date from response
+		WPOA_Session::set_token($access_token);
+		WPOA_Session::set_expires_in($expires_in);
+		WPOA_Session::set_expires_at($expires_at);
 		return true;
 	}
 }
@@ -137,7 +135,7 @@ function get_oauth_identity($wpoa) {
 	// here we exchange the access token for the user info...
 	// set the access token param:
 	$params = array(
-		'access_token' => $_SESSION['WPOA']['ACCESS_TOKEN'], // PROVIDER SPECIFIC: the access token is passed to itembase using this key name
+		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to itembase using this key name
 	);
 	$url_params = http_build_query($params);
 	// perform the http request:
@@ -155,7 +153,7 @@ function get_oauth_identity($wpoa) {
 			$opts = array('http' =>
 				array(
 					'method' => 'GET',
-					'header'  => "Authorization: token " . $_SESSION['WPOA']['ACCESS_TOKEN'],
+					'header'  => "Authorization: token " . WPOA_Session::get_token(),
 				)
 			);
 			$context = $context  = stream_context_create($opts);
@@ -168,7 +166,7 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = $_SESSION['WPOA']['PROVIDER'];
+	$oauth_identity['provider'] = WPOA_Session::get_provider();
 	$oauth_identity['id'] = $result_obj['uuid']; // PROVIDER SPECIFIC: this is how itembase returns the user's unique id
 	// $oauth_identity['email'] = $result_obj['email']; //PROVIDER SPECIFIC: this is how itembase returns the email address
 	if (!$oauth_identity['id']) {

--- a/login-itembase.php
+++ b/login-itembase.php
@@ -166,10 +166,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['uuid']; // PROVIDER SPECIFIC: this is how itembase returns the user's unique id
-	// $oauth_identity['email'] = $result_obj['email']; //PROVIDER SPECIFIC: this is how itembase returns the email address
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['uuid']; // PROVIDER SPECIFIC: this is how itembase returns the user's unique id
+	// $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['email']; //PROVIDER SPECIFIC: this is how itembase returns the email address
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-linkedin.php
+++ b/login-linkedin.php
@@ -1,12 +1,8 @@
 <?php
-
-// start the user session for maintaining individual user states during the multi-stage authentication flow:
-if (!isset($_SESSION)) {
-    session_start();
-}
+include_once 'session.php';
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-$_SESSION['WPOA']['PROVIDER'] = 'LinkedIn';
+WPOA_Session::set_provider('LinkedIn');
 define('HTTP_UTIL', get_option('wpoa_http_util'));
 define('CLIENT_ENABLED', get_option('wpoa_linkedin_api_enabled'));
 define('CLIENT_ID', get_option('wpoa_linkedin_api_id'));
@@ -18,17 +14,7 @@ define('URL_TOKEN', "https://www.linkedin.com/uas/oauth2/accessToken?");
 define('URL_USER', "https://api.linkedin.com/v1/people/~:(id,email-address)?");
 # END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-// remember the user's last url so we can redirect them back to there after the login ends:
-if (!$_SESSION['WPOA']['LAST_URL']) {
-	// try to obtain the redirect_url from the default login page:
-	$redirect_url = esc_url($_GET['redirect_to']);
-	// if no redirect_url was found, set it to the user's last page:
-	if (!$redirect_url) {
-		$redirect_url = strtok($_SERVER['HTTP_REFERER'], "?");
-	}
-	// set the user's last page so we can return that user there after they login:
-	$_SESSION['WPOA']['LAST_URL'] = $redirect_url;
-}
+WPOA_Session::save_last_url();
 
 # AUTHENTICATION FLOW #
 // the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
@@ -49,7 +35,7 @@ elseif (isset($_GET['error_message'])) {
 }
 elseif (isset($_GET['code'])) {
 	// post-auth phase, verify the state:
-	if ($_SESSION['WPOA']['STATE'] == $_GET['state']) {
+	if (WPOA_Session::get_state() == $_GET['state']) {
 		// get an access token from the third party provider:
 		get_oauth_token($this);
 		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
@@ -64,7 +50,7 @@ elseif (isset($_GET['code'])) {
 }
 else {
 	// pre-auth, start the auth process:
-	if ((empty($_SESSION['WPOA']['EXPIRES_AT'])) || (time() > $_SESSION['WPOA']['EXPIRES_AT'])) {
+	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
 		// expired token; clear the state:
 		$this->wpoa_clear_login_state();
 	}
@@ -83,7 +69,7 @@ function get_oauth_code($wpoa) {
 		'state' => uniqid('', true),
 		'redirect_uri' => REDIRECT_URI,
 	);
-	$_SESSION['WPOA']['STATE'] = $params['state'];
+	WPOA_Session::set_state($params['state']);
 	$url = URL_AUTH . http_build_query($params);
 	header("Location: $url");
 	exit;
@@ -139,9 +125,9 @@ function get_oauth_token($wpoa) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
 	}
 	else {
-		$_SESSION['WPOA']['ACCESS_TOKEN'] = $access_token;
-		$_SESSION['WPOA']['EXPIRES_IN'] = $expires_in;
-		$_SESSION['WPOA']['EXPIRES_AT'] = $expires_at;
+		WPOA_Session::set_token($access_token);
+		WPOA_Session::set_expires_in($expires_in);
+		WPOA_Session::set_expires_at($expires_at);
 		return true;
 	}
 }
@@ -150,7 +136,7 @@ function get_oauth_identity($wpoa) {
 	// here we exchange the access token for the user info...
 	// set the access token param:
 	$params = array(
-		'oauth2_access_token' => $_SESSION['WPOA']['ACCESS_TOKEN'], // PROVIDER SPECIFIC: the access token is passed to LinkedIn using this key name
+		'oauth2_access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to LinkedIn using this key name
 	);
 	$url_params = http_build_query($params);
 	// perform the http request:
@@ -171,7 +157,7 @@ function get_oauth_identity($wpoa) {
 				array(
 					'method'  => 'GET',
 					// PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
-					'header'  => "Authorization: Bearer " . $_SESSION['WPOA']['ACCESS_TOKEN'] . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: we must specify json or else LinkedIn will encode the result as xml by default
+					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: we must specify json or else LinkedIn will encode the result as xml by default
 				)
 			);
 			$context = $context  = stream_context_create($opts);
@@ -184,7 +170,7 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = $_SESSION['WPOA']['PROVIDER'];
+	$oauth_identity['provider'] = WPOA_Session::get_provider();
 	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how LinkedIn returns the user's unique id
 	//$oauth_identity['email'] = $result_obj['emailAddress']; //PROVIDER SPECIFIC: this is how LinkedIn returns the email address
 	if (!$oauth_identity['id']) {

--- a/login-linkedin.php
+++ b/login-linkedin.php
@@ -1,182 +1,40 @@
 <?php
+
 include_once 'session.php';
+include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('LinkedIn');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_linkedin_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_linkedin_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_linkedin_api_secret'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'r_basicprofile'); // PROVIDER SPECIFIC: 'r_basicprofile' is the minimum scope required to get the user's id from LinkedIn
-define('URL_AUTH', "https://www.linkedin.com/uas/oauth2/authorization?");
-define('URL_TOKEN', "https://www.linkedin.com/uas/oauth2/accessToken?");
-define('URL_USER', "https://api.linkedin.com/v1/people/~:(id,email-address)?");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-WPOA_Session::save_last_url();
+error_reporting(E_ALL | E_STRICT);
 
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
-	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
+class LoginLinkedin extends AbstractLoginCommon {
+  public function __construct($wpoa) {
+    parent::__construct('LinkedIn', 
+      "https://www.linkedin.com/oauth/v2/authorization?", 
+      "https://www.linkedin.com/oauth/v2/accessToken", 
+      "https://api.linkedin.com/v1/people/~:(id,email-address,formatted-name)?",
+      $wpoa);
+    $this->useBearer = true;
+  }
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
-	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
+  
+  function getOAuthCodeExtendArray($array){
+    $array['scope'] = 'r_basicprofile r_emailaddress';
+    return $array;
+  }
+  
+  function getOAuthIdentityParameters(){
+  return array();
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+  $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+  $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['formattedName'];
+  $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['emailAddress'];
+
+  return $oauth_identity;
+  }
 }
 
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			// PROVIDER NORMALIZATION: Reddit requires sending a User-Agent header...
-			// PROVIDER NORMALIZATION: Reddit requires sending the client id/secret via http basic authentication
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, (get_option('wpoa_http_util_verify_ssl') == 1 ? 1 : 0));
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, (get_option('wpoa_http_util_verify_ssl') == 1 ? 2 : 0));
-			$result = curl_exec($curl);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_TOKEN, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	$result_obj = json_decode($result, true); // PROVIDER SPECIFIC: LinkedIn encodes the access token result as json by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how LinkedIn returns the access token KEEP THIS PROTECTED!
-	$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: this is how LinkedIn returns the access token's expiration
-	$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
-}
 
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		'oauth2_access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to LinkedIn using this key name
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_USER . $url_params; // TODO: we probably want to send this using a curl_setopt...
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			// PROVIDER NORMALIZATION: Github/Reddit require a User-Agent here...
-			curl_setopt($curl, CURLOPT_HTTPHEADER, array('x-li-format: json')); // PROVIDER SPECIFIC: we must specify json or else LinkedIn will encode the result as xml by default // PROVIDER NORMALIZATION: PayPal/Reddit require that we send the access token via a bearer header, PayPal also requires a Content-Type: application/json header...
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			$result = curl_exec($curl);
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: we must specify json or else LinkedIn will encode the result as xml by default
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how LinkedIn returns the user's unique id
-	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emailAddress']; //PROVIDER SPECIFIC: this is how LinkedIn returns the email address
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
-	return $oauth_identity;
-}
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
+$login = new LoginLinkedin($this);
+$login->run();

--- a/login-linkedin.php
+++ b/login-linkedin.php
@@ -7,32 +7,32 @@ include_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginLinkedin extends AbstractLoginCommon {
-  public function __construct($wpoa) {
-    parent::__construct('LinkedIn', 
-      "https://www.linkedin.com/oauth/v2/authorization?", 
-      "https://www.linkedin.com/oauth/v2/accessToken", 
-      "https://api.linkedin.com/v1/people/~:(id,email-address,formatted-name)?",
-      $wpoa);
-    $this->useBearer = true;
-  }
+    public function __construct($wpoa) {
+        parent::__construct('LinkedIn',
+                "https://www.linkedin.com/oauth/v2/authorization?",
+                "https://www.linkedin.com/oauth/v2/accessToken",
+                "https://api.linkedin.com/v1/people/~:(id,email-address,formatted-name)?",
+                $wpoa);
+        $this->useBearer = true;
+    }
 
-  
-  function getOAuthCodeExtendArray($array){
-    $array['scope'] = 'r_basicprofile r_emailaddress';
-    return $array;
-  }
-  
-  function getOAuthIdentityParameters(){
-  return array();
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-  $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
-  $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['formattedName'];
-  $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['emailAddress'];
 
-  return $oauth_identity;
-  }
+    function getOAuthCodeExtendArray($array){
+        $array['scope'] = 'r_basicprofile r_emailaddress';
+        return $array;
+    }
+
+    function getOAuthIdentityParameters(){
+        return array();
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['formattedName'];
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['emailAddress'];
+
+        return $oauth_identity;
+    }
 }
 
 

--- a/login-linkedin.php
+++ b/login-linkedin.php
@@ -170,10 +170,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how LinkedIn returns the user's unique id
-	//$oauth_identity['email'] = $result_obj['emailAddress']; //PROVIDER SPECIFIC: this is how LinkedIn returns the email address
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how LinkedIn returns the user's unique id
+	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emailAddress']; //PROVIDER SPECIFIC: this is how LinkedIn returns the email address
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-oauth_server.php
+++ b/login-oauth_server.php
@@ -186,12 +186,12 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['ID']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['ID']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
 	
 	// print_r( $oauth_identity ); exit;
-	// $oauth_identity['email'] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-	if (!$oauth_identity['id']) {
+	// $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-oauth_server.php
+++ b/login-oauth_server.php
@@ -1,12 +1,9 @@
 <?php
 
-// start the user session for maintaining individual user states during the multi-stage authentication flow:
-if (!isset($_SESSION)) {
-    session_start();
-}
+include_once 'session.php';
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-$_SESSION['WPOA']['PROVIDER'] = 'oauth_server';
+WPOA_Session::set_provider('oauth_server');
 define('HTTP_UTIL', get_option('wpoa_http_util'));
 define('CLIENT_ENABLED', get_option('wpoa_oauth_server_api_enabled'));
 define('CLIENT_ID', get_option('wpoa_oauth_server_api_id'));
@@ -18,18 +15,7 @@ define('URL_TOKEN', get_option('wpoa_oauth_server_api_endpoint') . "?oauth=token
 define('URL_USER', get_option('wpoa_oauth_server_api_endpoint') . "?oauth=me&");
 # END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-// remember the user's last url so we can redirect them back to there after the login ends:
-if (!$_SESSION['WPOA']['LAST_URL']) {
-
-	// try to obtain the redirect_url from the default login page:
-	$redirect_url = esc_url($_GET['redirect_to']);
-	// if no redirect_url was found, set it to the user's last page:
-	if (!$redirect_url) {
-		$redirect_url = strtok($_SERVER['HTTP_REFERER'], "?");
-	}
-	// set the user's last page so we can return that user there after they login:
-	$_SESSION['WPOA']['LAST_URL'] = $redirect_url;
-}
+WPOA_Session::save_last_url();
 
 # AUTHENTICATION FLOW #
 // the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
@@ -50,7 +36,7 @@ elseif (isset($_GET['error_message'])) {
 }
 elseif (isset($_GET['code'])) {
 	// post-auth phase, verify the state:
-	if ($_SESSION['WPOA']['STATE'] == $_GET['state']) {
+	if (WPOA_Session::get_state() == $_GET['state']) {
 
 		// get an access token from the third party provider:
 		get_oauth_token($this);
@@ -68,7 +54,7 @@ else {
 	//print'pre auth'; exit;
 
 	// pre-auth, start the auth process:
-	if ((empty($_SESSION['WPOA']['EXPIRES_AT'])) || (time() > $_SESSION['WPOA']['EXPIRES_AT'])) {
+	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
 		// expired token; clear the state:
 		$this->wpoa_clear_login_state();
 	}
@@ -89,7 +75,7 @@ function get_oauth_code($wpoa) {
 	);
 
 	//print_r( $params ); exit;
-	$_SESSION['WPOA']['STATE'] = $params['state'];
+	WPOA_Session::set_state($params['state']);
 	$url = URL_AUTH . http_build_query($params);
 	header("Location: $url");
 	exit;
@@ -149,11 +135,11 @@ function get_oauth_token($wpoa) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
 	}
 	else {
-		$_SESSION['WPOA']['ACCESS_TOKEN'] = $access_token;
-		$_SESSION['WPOA']['EXPIRES_IN'] = $expires_in;
-		$_SESSION['WPOA']['EXPIRES_AT'] = $expires_at;
+		WPOA_Session::set_token($access_token);
+		WPOA_Session::set_expires_in($expires_in);
+		WPOA_Session::set_expires_at($expires_at);
 
-		//print_r( $_SESSION['WPOA'] ); exit;
+		//print_r( WPOA_Session::get_provider['WPOA'] ); exit;
 		return true;
 	}
 }
@@ -164,7 +150,7 @@ function get_oauth_identity($wpoa) {
 	// here we exchange the access token for the user info...
 	// set the access token param:
 	$params = array(
-		'access_token' => $_SESSION['WPOA']['ACCESS_TOKEN'], // PROVIDER SPECIFIC: the access_token is passed to Google via POST param
+		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access_token is passed to Google via POST param
 	);
 	$url_params = http_build_query($params);
 	// perform the http request:
@@ -187,7 +173,7 @@ function get_oauth_identity($wpoa) {
 				array(
 					'method'  => 'GET',
 					// PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
-					'header'  => "Authorization: Bearer " . $_SESSION['WPOA']['ACCESS_TOKEN'] . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
+					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
 				)
 			);
 			$context = $context  = stream_context_create($opts);
@@ -200,7 +186,7 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = $_SESSION['WPOA']['PROVIDER'];
+	$oauth_identity['provider'] = WPOA_Session::get_provider();
 	$oauth_identity['id'] = $result_obj['ID']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
 	
 	// print_r( $oauth_identity ); exit;

--- a/login-paypal.php
+++ b/login-paypal.php
@@ -6,45 +6,45 @@ include_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginPaypal extends AbstractLoginCommon {
-  public function __construct($wpoa) {
-    $isSandbox = get_option('wpoa_paypal_api_sandbox_mode');
-    $sandBoxOrNothing = $isSandbox ? "sandbox." : "";
-    
-    parent::__construct('PayPal', 
-      "https://www." . $sandBoxOrNothing . "paypal.com/webapps/auth/protocol/openidconnect/v1/authorize?",
-      "https://api." . $sandBoxOrNothing . "paypal.com/v1/identity/openidconnect/tokenservice?",
-      "https://api." . $sandBoxOrNothing . "paypal.com/v1/identity/openidconnect/userinfo/",
-      $wpoa);
-    $this->useBearer = true;
-    $this->sendIdAndSecretInHeader = true;
-  }
+    public function __construct($wpoa) {
+        $isSandbox = get_option('wpoa_paypal_api_sandbox_mode');
+        $sandBoxOrNothing = $isSandbox ? "sandbox." : "";
 
-  
-  function getOAuthCodeExtendArray($array){
-    $array['scope'] = 'openid profile email';
-    return $array;
-  }
+        parent::__construct('PayPal',
+                "https://www." . $sandBoxOrNothing . "paypal.com/webapps/auth/protocol/openidconnect/v1/authorize?",
+                "https://api." . $sandBoxOrNothing . "paypal.com/v1/identity/openidconnect/tokenservice?",
+                "https://api." . $sandBoxOrNothing . "paypal.com/v1/identity/openidconnect/userinfo/",
+                $wpoa);
+        $this->useBearer = true;
+        $this->sendIdAndSecretInHeader = true;
+    }
 
-  function getOAuthTokenExtendArray($array) {
-    $array['client_id'] = null;
-    $array['client_secret'] = null;
-    $array['redirect_uri'] = null;
-    
-    return $array;
-  }
-  
-  function getOAuthIdentityParameters(){
-    return array("schema" => "openid",
-                 "access_token" => WPOA_Session::get_token());
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['user_id'];
-    $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
-    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
 
-    return $oauth_identity;
-  }
+    function getOAuthCodeExtendArray($array){
+        $array['scope'] = 'openid profile email';
+        return $array;
+    }
+
+    function getOAuthTokenExtendArray($array) {
+        $array['client_id'] = null;
+        $array['client_secret'] = null;
+        $array['redirect_uri'] = null;
+
+        return $array;
+    }
+
+    function getOAuthIdentityParameters(){
+        return array("schema" => "openid",
+                "access_token" => WPOA_Session::get_token());
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['user_id'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+
+        return $oauth_identity;
+    }
 }
 
 $login = new LoginPaypal($this);

--- a/login-paypal.php
+++ b/login-paypal.php
@@ -1,183 +1,51 @@
 <?php
 
 include_once 'session.php';
+include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('PayPal');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_paypal_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_paypal_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_paypal_api_secret'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'openid'); // PROVIDER SPECIFIC: 'openid' is the minimum scope required to get the user's id from paypal
-define('URL_AUTH', "https://www." . (get_option('wpoa_paypal_api_sandbox_mode') ? "sandbox." : "") . "paypal.com/webapps/auth/protocol/openidconnect/v1/authorize?");
-define('URL_TOKEN', "https://api." . (get_option('wpoa_paypal_api_sandbox_mode') ? "sandbox." : "") . "paypal.com/v1/identity/openidconnect/tokenservice?");
-define('URL_USER', "https://api." . (get_option('wpoa_paypal_api_sandbox_mode') ? "sandbox." : "") . "paypal.com/v1/identity/openidconnect/userinfo/?schema=openid");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
+error_reporting(E_ALL | E_STRICT);
 
-WPOA_Session::save_last_url();
+class LoginPaypal extends AbstractLoginCommon {
+  public function __construct($wpoa) {
+    $isSandbox = get_option('wpoa_paypal_api_sandbox_mode');
+    $sandBoxOrNothing = $isSandbox ? "sandbox." : "";
+    
+    parent::__construct('PayPal', 
+      "https://www." . $sandBoxOrNothing . "paypal.com/webapps/auth/protocol/openidconnect/v1/authorize?",
+      "https://api." . $sandBoxOrNothing . "paypal.com/v1/identity/openidconnect/tokenservice?",
+      "https://api." . $sandBoxOrNothing . "paypal.com/v1/identity/openidconnect/userinfo/",
+      $wpoa);
+    $this->useBearer = true;
+    $this->sendIdAndSecretInHeader = true;
+  }
 
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
-	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
+  
+  function getOAuthCodeExtendArray($array){
+    $array['scope'] = 'openid profile email';
+    return $array;
+  }
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
-	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
+  function getOAuthTokenExtendArray($array) {
+    $array['client_id'] = null;
+    $array['client_secret'] = null;
+    $array['redirect_uri'] = null;
+    
+    return $array;
+  }
+  
+  function getOAuthIdentityParameters(){
+    return array("schema" => "openid",
+                 "access_token" => WPOA_Session::get_token());
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['user_id'];
+    $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['email'];
+
+    return $oauth_identity;
+  }
 }
 
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		// PROVIDER NORMALIZATION: Google passes the client_id via POST parameter
-		// PROVIDER NORMALIZATION: Google passes the client_secret via POST parameter
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			curl_setopt($curl, CURLOPT_HTTPHEADER, array("Accept: application/json", "Accept-Language: en_US")); // PROVIDER SPECIFIC: PayPal requires Accept and Accept-Language headers, Reddit requires sending a User-Agent header
-			curl_setopt($curl, CURLOPT_USERPWD, CLIENT_ID . ":" . CLIENT_SECRET); // PROVIDER SPECIFIC: PayPal/Reddit requires sending the client id/secret via http basic authentication
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, (get_option('wpoa_http_util_verify_ssl') == 1 ? 1 : 0));
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, (get_option('wpoa_http_util_verify_ssl') == 1 ? 2 : 0));
-			$result = curl_exec($curl);
-			break;
-		case 'stream-context':
-			$url = $wpoa->wpoa_add_basic_auth(rtrim(URL_TOKEN, "?"), CLIENT_ID, CLIENT_SECRET); // PROVIDER SPECIFIC: Reddit/PayPal requires basic authentication with the request
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	$result_obj = json_decode($result, true); // PROVIDER SPECIFIC: Google encodes the access token result as json by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Google returns the access token KEEP THIS PROTECTED!
-	$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: this is how Google returns the access token's expiration
-	$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
-}
-
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		// PROVIDER NORMALIZATION: the access_token is passed to Google via POST param
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_USER . $url_params;
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			// PROVIDER NORMALIZATION: Github/Reddit require a User-Agent here...
-			curl_setopt($curl, CURLOPT_HTTPHEADER, array("Content-Type: application/json", "Authorization: Bearer " . WPOA_Session::get_token())); // PROVIDER SPECIFIC: PayPal/Reddit require that we send the access token via a bearer header, PayPal requires a Content-Type: application/json header, LinkedIn requires an x-li-format: json header
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			$result = curl_exec($curl);
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github User-Agent
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['user_id']; // PROVIDER SPECIFIC: PayPal returns the user's OAuth identity as user_id
-	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
-	return $oauth_identity;
-}
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
+$login = new LoginPaypal($this);
+$login->run();

--- a/login-paypal.php
+++ b/login-paypal.php
@@ -171,10 +171,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['user_id']; // PROVIDER SPECIFIC: PayPal returns the user's OAuth identity as user_id
-	//$oauth_identity['email'] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['user_id']; // PROVIDER SPECIFIC: PayPal returns the user's OAuth identity as user_id
+	//$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['emails'][0]['value']; // PROVIDER SPECIFIC: Google returns an array of email addresses. To respect privacy we currently don't collect the user's email address.
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-reddit.php
+++ b/login-reddit.php
@@ -38,7 +38,7 @@ class LoginReddit extends AbstractLoginCommon {
         $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
         $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
         // TODO : Reddit does not send email. If they implement it, we must update the following line.
-        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['name'] . "@reddit.com";
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['name'] . "@example.com";
 
         return $oauth_identity;
     }

--- a/login-reddit.php
+++ b/login-reddit.php
@@ -1,12 +1,9 @@
 <?php
 
-// start the user session for maintaining individual user states during the multi-stage authentication flow:
-if (!isset($_SESSION)) {
-    session_start();
-}
+include_once 'session.php';
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-$_SESSION['WPOA']['PROVIDER'] = 'Reddit';
+WPOA_Session::set_provider('Reddit');
 define('HTTP_UTIL', get_option('wpoa_http_util'));
 define('CLIENT_ENABLED', get_option('wpoa_reddit_api_enabled'));
 define('CLIENT_ID', get_option('wpoa_reddit_api_id'));
@@ -18,8 +15,7 @@ define('URL_TOKEN', "https://ssl.reddit.com/api/v1/access_token?");
 define('URL_USER', "https://oauth.reddit.com/api/v1/me?");
 # END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-// remember the user's last url so we can redirect them back to there after the login ends:
-if (!$_SESSION['WPOA']['LAST_URL']) {$_SESSION['WPOA']['LAST_URL'] = strtok($_SERVER['HTTP_REFERER'], "?");}
+WPOA_Session::save_last_url();
 
 # AUTHENTICATION FLOW #
 // the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
@@ -40,7 +36,7 @@ elseif (isset($_GET['error_message'])) {
 }
 elseif (isset($_GET['code'])) {
 	// post-auth phase, verify the state:
-	if ($_SESSION['WPOA']['STATE'] == $_GET['state']) {
+	if (WPOA_Session::get_state() == $_GET['state']) {
 		// get an access token from the third party provider:
 		get_oauth_token($this);
 		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
@@ -55,7 +51,7 @@ elseif (isset($_GET['code'])) {
 }
 else {
 	// pre-auth, start the auth process:
-	if ((empty($_SESSION['WPOA']['EXPIRES_AT'])) || (time() > $_SESSION['WPOA']['EXPIRES_AT'])) {
+	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
 		// expired token; clear the state:
 		$this->wpoa_clear_login_state();
 	}
@@ -74,7 +70,7 @@ function get_oauth_code($wpoa) {
 		'state' => uniqid('', true),
 		'redirect_uri' => REDIRECT_URI,
 	);
-	$_SESSION['WPOA']['STATE'] = $params['state'];
+	WPOA_Session::set_state($params['state']);
 	$url = URL_AUTH . http_build_query($params);
 	header("Location: $url");
 	exit;
@@ -130,9 +126,9 @@ function get_oauth_token($wpoa) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
 	}
 	else {
-		$_SESSION['WPOA']['ACCESS_TOKEN'] = $access_token;
-		$_SESSION['WPOA']['EXPIRES_IN'] = $expires_in;
-		$_SESSION['WPOA']['EXPIRES_AT'] = $expires_at;
+		WPOA_Session::set_token($access_token);
+		WPOA_Session::set_expires_in($expires_in);
+		WPOA_Session::set_expires_at($expires_at);
 		return true;
 	}
 }
@@ -141,7 +137,7 @@ function get_oauth_identity($wpoa) {
 	// here we exchange the access token for the user info...
 	// set the access token param:
 	$params = array(
-		'access_token' => $_SESSION['WPOA']['ACCESS_TOKEN'], // PROVIDER SPECIFIC: the access token is passed to Reddit using this key name
+		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to Reddit using this key name
 	);
 	$url_params = http_build_query($params);
 	// perform the http request:
@@ -151,7 +147,7 @@ function get_oauth_identity($wpoa) {
 			$curl = curl_init();
 			curl_setopt($curl, CURLOPT_URL, $url);
 			curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // PROVIDER SPECIFIC: Reddit requires a User-Agent
-			curl_setopt($curl, CURLOPT_HTTPHEADER, array("Authorization: bearer " . $_SESSION['WPOA']['ACCESS_TOKEN'])); // PROVIDER SPECIFIC: the access token must be sent to Reddit as a bearer header
+			curl_setopt($curl, CURLOPT_HTTPHEADER, array("Authorization: bearer " . WPOA_Session::get_token())); // PROVIDER SPECIFIC: the access token must be sent to Reddit as a bearer header
 			// PROVIDER NORMALIZATION: LinkedIn requires an x-li-format: json header...
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 			$result = curl_exec($curl);
@@ -163,7 +159,7 @@ function get_oauth_identity($wpoa) {
 				array(
 					'method'  => 'GET',
 					'user_agent' => $_SERVER['HTTP_USER_AGENT'], // PROVIDER SPECIFIC: Reddit requires a User-Agent
-					'header'  => "Authorization: bearer " . $_SESSION['WPOA']['ACCESS_TOKEN'], // PROVIDER SPECIFIC: the access token must be sent to Reddit as a bearer header
+					'header'  => "Authorization: bearer " . WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token must be sent to Reddit as a bearer header
 				)
 			);
 			$context = $context  = stream_context_create($opts);
@@ -176,7 +172,7 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = $_SESSION['WPOA']['PROVIDER'];
+	$oauth_identity['provider'] = WPOA_Session::get_provider();
 	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Reddit returns the user's unique id
 	//$oauth_identity['email'] = 'not_provided'; // PROVIDER SPECIFIC: Reddit never provides the user's email!
 	if (!$oauth_identity['id']) {

--- a/login-reddit.php
+++ b/login-reddit.php
@@ -1,184 +1,48 @@
 <?php
 
 include_once 'session.php';
+include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('Reddit');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_reddit_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_reddit_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_reddit_api_secret'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'identity'); // PROVIDER SPECIFIC: 'identity' is the minimum scope required to get the user's id from Reddit
-define('URL_AUTH', "https://ssl.reddit.com/api/v1/authorize?");
-define('URL_TOKEN', "https://ssl.reddit.com/api/v1/access_token?");
-define('URL_USER', "https://oauth.reddit.com/api/v1/me?");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
+error_reporting(E_ALL | E_STRICT);
 
-WPOA_Session::save_last_url();
+class LoginReddit extends AbstractLoginCommon {
+  public function __construct($wpoa) {
+    parent::__construct('Reddit', 
+      "https://ssl.reddit.com/api/v1/authorize?",
+      "https://ssl.reddit.com/api/v1/access_token?",
+      "https://oauth.reddit.com/api/v1/me",
+      $wpoa);
+    $this->useBearer = true;
+	$this->sendIdAndSecretInHeader = true;
+  }
 
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
-	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
+  
+  function getOAuthCodeExtendArray($array) {
+    $array['scope'] = 'identity';
+    return $array;
+  }
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
-	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
+  function getOAuthTokenExtendArray($array) {
+    $array['client_id'] = null;
+    $array['client_secret'] = null;
+    
+    return $array;
+  }
+  
+  function getOAuthIdentityParameters(){
+    return array("schema" => "openid",
+                 "access_token" => WPOA_Session::get_token());
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+    $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+	// TODO : Reddit does not send email. If they implement it, we must update the following line.
+    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['name'] . "@reddit.com";
+
+    return $oauth_identity;
+  }
 }
 
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params);
-			curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // PROVIDER SPECIFIC: Reddit requires a User-Agent
-			curl_setopt($curl, CURLOPT_USERPWD, CLIENT_ID . ":" . CLIENT_SECRET); // PROVIDER SPECIFIC: Reddit requires basic authentication with this request
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, (get_option('wpoa_http_util_verify_ssl') == 1 ? 1 : 0));
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, (get_option('wpoa_http_util_verify_ssl') == 1 ? 2 : 0));
-			$result = curl_exec($curl);
-			break;
-		case 'stream-context':
-			$url = $wpoa->wpoa_add_basic_auth(rtrim(URL_TOKEN, "?"), CLIENT_ID, CLIENT_SECRET); // PROVIDER SPECIFIC: Reddit requires basic authentication with the request
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	$result_obj = json_decode($result, true); // PROVIDER SPECIFIC: Reddit encodes the access token result as json by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Reddit returns the access token KEEP THIS PROTECTED!
-	$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: this is how Reddit returns the access token's expiration
-	$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
-}
-
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token is passed to Reddit using this key name
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = rtrim(URL_USER, "?");
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // PROVIDER SPECIFIC: Reddit requires a User-Agent
-			curl_setopt($curl, CURLOPT_HTTPHEADER, array("Authorization: bearer " . WPOA_Session::get_token())); // PROVIDER SPECIFIC: the access token must be sent to Reddit as a bearer header
-			// PROVIDER NORMALIZATION: LinkedIn requires an x-li-format: json header...
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			$result = curl_exec($curl);
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					'user_agent' => $_SERVER['HTTP_USER_AGENT'], // PROVIDER SPECIFIC: Reddit requires a User-Agent
-					'header'  => "Authorization: bearer " . WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access token must be sent to Reddit as a bearer header
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Reddit returns the user's unique id
-	//$oauth_identity[WPOA_Session::USER_NAME] = 'not_provided'; // PROVIDER SPECIFIC: Reddit never provides the user's email!
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
-	return $oauth_identity;
-}
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
+$login = new LoginReddit($this);
+$login->run();

--- a/login-reddit.php
+++ b/login-reddit.php
@@ -6,42 +6,42 @@ include_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginReddit extends AbstractLoginCommon {
-  public function __construct($wpoa) {
-    parent::__construct('Reddit', 
-      "https://ssl.reddit.com/api/v1/authorize?",
-      "https://ssl.reddit.com/api/v1/access_token?",
-      "https://oauth.reddit.com/api/v1/me",
-      $wpoa);
-    $this->useBearer = true;
-	$this->sendIdAndSecretInHeader = true;
-  }
+    public function __construct($wpoa) {
+        parent::__construct('Reddit',
+                "https://ssl.reddit.com/api/v1/authorize?",
+                "https://ssl.reddit.com/api/v1/access_token?",
+                "https://oauth.reddit.com/api/v1/me",
+                $wpoa);
+        $this->useBearer = true;
+        $this->sendIdAndSecretInHeader = true;
+    }
 
-  
-  function getOAuthCodeExtendArray($array) {
-    $array['scope'] = 'identity';
-    return $array;
-  }
 
-  function getOAuthTokenExtendArray($array) {
-    $array['client_id'] = null;
-    $array['client_secret'] = null;
-    
-    return $array;
-  }
-  
-  function getOAuthIdentityParameters(){
-    return array("schema" => "openid",
-                 "access_token" => WPOA_Session::get_token());
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-    $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
-    $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
-	// TODO : Reddit does not send email. If they implement it, we must update the following line.
-    $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['name'] . "@reddit.com";
+    function getOAuthCodeExtendArray($array) {
+        $array['scope'] = 'identity';
+        return $array;
+    }
 
-    return $oauth_identity;
-  }
+    function getOAuthTokenExtendArray($array) {
+        $array['client_id'] = null;
+        $array['client_secret'] = null;
+
+        return $array;
+    }
+
+    function getOAuthIdentityParameters(){
+        return array("schema" => "openid",
+                "access_token" => WPOA_Session::get_token());
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['id'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['name'];
+        // TODO : Reddit does not send email. If they implement it, we must update the following line.
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['name'] . "@reddit.com";
+
+        return $oauth_identity;
+    }
 }
 
 $login = new LoginReddit($this);

--- a/login-reddit.php
+++ b/login-reddit.php
@@ -172,10 +172,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = WPOA_Session::get_provider();
-	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Reddit returns the user's unique id
-	//$oauth_identity['email'] = 'not_provided'; // PROVIDER SPECIFIC: Reddit never provides the user's email!
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Reddit returns the user's unique id
+	//$oauth_identity[WPOA_Session::USER_NAME] = 'not_provided'; // PROVIDER SPECIFIC: Reddit never provides the user's email!
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-windowsazure.php
+++ b/login-windowsazure.php
@@ -29,10 +29,7 @@ class LoginAzure extends AbstractLoginCommon {
     }
 
     function getOAuthIdentityParameters(){
-        $params = array(
-                'api-version' => "1.6",
-                );
-        return $params;
+        return array('api-version' => "1.6");
     }
 
     function getOAuthIdentityFillArray($result_obj, $oauth_identity){

--- a/login-windowsazure.php
+++ b/login-windowsazure.php
@@ -19,180 +19,47 @@ define('URL_USER', "GRAPH" . TENANT_ID . "/me?");
 
 # END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-WPOA_Session::save_last_url();
+error_reporting(E_ALL | E_STRICT);
 
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
+class LoginAzure extends AbstractLoginCommon {
+	public function __construct($wpoa) {
+		$tenant = get_option('wpoa_windowsazure_tenant_id');
+		parent::__construct('Windows Azure', 
+			"https://login.microsoftonline.com/$tenant/oauth2/authorize?", 
+			"https://login.microsoftonline.com/$tenant/oauth2/token", 
+			"https://graph.windows.net/$tenant/me?",
+			$wpoa);
+		$this->useBearer = true;
 	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-		WPOA_Session::set_provider('Windows Azure');
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
+	
+  function getOAuthCodeExtendArray($array){
+	  $array['scope'] = 'https%3A%2F%2Fgraph.microsoft.com%2Fmail.read';
+	  $array['resource'] = "https://graph.windows.net";
+	  return $array;
+  }
+
+  function getOAuthTokenExtendArray($array) {
+	  $array['resource'] = "https://graph.windows.net";
+	  return $array;
+  }
+  
+  function getOAuthIdentityParameters(){
 	$params = array(
-		'response_type' => 'code',
-		'response_mode' => 'query',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
-		'resource' => GRAPH
+		'api-version' => "1.6",
 	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	Logger::Instance()->log("AZURE : Get Oauth code from : " . $url);
-	header("Location: $url");
-	exit;
-}
-
-function get_oauth_token($wpoa) {
-	Logger::Instance()->log("AZURE : get_oauth_token");
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-		'resource' => GRAPH,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$url = URL_TOKEN;
-			$curl = init_curl($url);
-			// curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $params); // TODO: for Google we use $params...
-			// PROVIDER NORMALIZATION: Reddit requires sending a User-Agent header...
-			// PROVIDER NORMALIZATION: Reddit requires sending the client id/secret via http basic authentication...
-			
-			$result = exec_curl($curl, "Get oauth token");
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_TOKEN, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	$result_obj = json_decode($result, true); // PROVIDER SPECIFIC: Windows Live encodes the access token result as json by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Windows Live returns the access token KEEP THIS PROTECTED!
-	$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: this is how Windows Live returns the access token's expiration
-	$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
-}
-
-function get_oauth_identity($wpoa) {
-	Logger::Instance()->log("AZURE : get_oauth_identity");
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$access_token = WPOA_Session::get_token();
-	Logger::Instance()->log("AZURE : token = " .$access_token);
-	$params = array(
-		"api-version" => "1.6",
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = GRAPH . TENANT_ID . "/me?";
-			$url .= $url_params;
-			$curl = init_curl($url);
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // TODO: does Windows Live require this?
-			curl_setopt($curl, CURLOPT_HTTPHEADER, array("Authorization: Bearer " . $access_token)); // PROVIDER SPECIFIC: do we have to do this for Windows Live?
-			// curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: application/json')); // PROVIDER SPECIFIC: I think this is only for LinkedIn...
-			
-			$result = exec_curl($curl, "get oauth identity");
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['objectId']; // PROVIDER SPECIFIC: Google returns the user's OAuth identity as id
+	return $params;
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['objectId'];
 	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['displayName'];
 	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['userPrincipalName'];
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
+
 	return $oauth_identity;
+  }
 }
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
+
+
+$azure = new LoginAzure($this);
+$azure->run();

--- a/login-windowsazure.php
+++ b/login-windowsazure.php
@@ -3,22 +3,6 @@
 include_once 'session.php';
 include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('Windows Azure');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_windowsazure_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_windowsazure_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_windowsazure_api_secret'));
-define('TENANT_ID', get_option('wpoa_windowsazure_tenant_id'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'https%3A%2F%2Fgraph.microsoft.com%2Fmail.read');
-define('URL_AUTH', "https://login.microsoftonline.com/" . TENANT_ID . "/oauth2/authorize?");
-define('URL_TOKEN', "https://login.microsoftonline.com/" . TENANT_ID . "/oauth2/token");
-define('GRAPH', "https://graph.windows.net/");
-define('URL_USER', "GRAPH" . TENANT_ID . "/me?");
-
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-
 error_reporting(E_ALL | E_STRICT);
 
 class LoginAzure extends AbstractLoginCommon {

--- a/login-windowsazure.php
+++ b/login-windowsazure.php
@@ -6,42 +6,42 @@ include_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginAzure extends AbstractLoginCommon {
-	public function __construct($wpoa) {
-		$tenant = get_option('wpoa_windowsazure_tenant_id');
-		parent::__construct('Windows Azure', 
-			"https://login.microsoftonline.com/$tenant/oauth2/authorize?", 
-			"https://login.microsoftonline.com/$tenant/oauth2/token", 
-			"https://graph.windows.net/$tenant/me?",
-			$wpoa);
-		$this->useBearer = true;
-	}
+    public function __construct($wpoa) {
+        $tenant = get_option('wpoa_windowsazure_tenant_id');
+        parent::__construct('Windows Azure',
+                "https://login.microsoftonline.com/$tenant/oauth2/authorize?",
+                "https://login.microsoftonline.com/$tenant/oauth2/token",
+                "https://graph.windows.net/$tenant/me?",
+                $wpoa);
+        $this->useBearer = true;
+    }
 
-	
-  function getOAuthCodeExtendArray($array){
-	  $array['scope'] = 'https%3A%2F%2Fgraph.microsoft.com%2Fmail.read';
-	  $array['resource'] = "https://graph.windows.net";
-	  return $array;
-  }
 
-  function getOAuthTokenExtendArray($array) {
-	  $array['resource'] = "https://graph.windows.net";
-	  return $array;
-  }
-  
-  function getOAuthIdentityParameters(){
-	$params = array(
-		'api-version' => "1.6",
-	);
-	return $params;
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['objectId'];
-	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['displayName'];
-	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['userPrincipalName'];
+    function getOAuthCodeExtendArray($array){
+        $array['scope'] = 'https%3A%2F%2Fgraph.microsoft.com%2Fmail.read';
+        $array['resource'] = "https://graph.windows.net";
+        return $array;
+    }
 
-	return $oauth_identity;
-  }
+    function getOAuthTokenExtendArray($array) {
+        $array['resource'] = "https://graph.windows.net";
+        return $array;
+    }
+
+    function getOAuthIdentityParameters(){
+        $params = array(
+                'api-version' => "1.6",
+                );
+        return $params;
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['objectId'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['displayName'];
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['userPrincipalName'];
+
+        return $oauth_identity;
+    }
 }
 
 

--- a/login-windowsazure.php
+++ b/login-windowsazure.php
@@ -79,13 +79,13 @@ function get_oauth_code($wpoa) {
 	);
 	WPOA_Session::set_state($params['state']);
 	$url = URL_AUTH . http_build_query($params);
-	$logger->log("AZURE : Get Oauth code from : " . $url);
+	Logger::Instance()->log("AZURE : Get Oauth code from : " . $url);
 	header("Location: $url");
 	exit;
 }
 
 function get_oauth_token($wpoa) {
-	$logger->log("AZURE : get_oauth_token");
+	Logger::Instance()->log("AZURE : get_oauth_token");
 	$params = array(
 		'grant_type' => 'authorization_code',
 		'client_id' => CLIENT_ID,
@@ -143,11 +143,11 @@ function get_oauth_token($wpoa) {
 }
 
 function get_oauth_identity($wpoa) {
-	$logger->log("AZURE : get_oauth_identity");
+	Logger::Instance()->log("AZURE : get_oauth_identity");
 	// here we exchange the access token for the user info...
 	// set the access token param:
 	$access_token = WPOA_Session::get_token();
-	$logger->log("AZURE : token = " .$access_token);
+	Logger::Instance()->log("AZURE : token = " .$access_token);
 	$params = array(
 		"api-version" => "1.6",
 	);

--- a/login-windowslive.php
+++ b/login-windowslive.php
@@ -27,10 +27,7 @@ class LoginWindowsLive extends AbstractLoginCommon {
     }
 
     function getOAuthIdentityParameters(){
-        $params = array(
-                'api-version' => "1.6",
-                );
-        return array();
+        return array('api-version' => "1.6");
     }
 
     function getOAuthIdentityFillArray($result_obj, $oauth_identity){

--- a/login-windowslive.php
+++ b/login-windowslive.php
@@ -1,12 +1,9 @@
 <?php
 
-// start the user session for maintaining individual user states during the multi-stage authentication flow:
-if (!isset($_SESSION)) {
-    session_start();
-}
+include_once 'session.php';
 
 # DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-$_SESSION['WPOA']['PROVIDER'] = 'Windows Live';
+WPOA_Session::set_provider('Windows Live');
 define('HTTP_UTIL', get_option('wpoa_http_util'));
 define('CLIENT_ENABLED', get_option('wpoa_windowslive_api_enabled'));
 define('CLIENT_ID', get_option('wpoa_windowslive_api_id'));
@@ -18,8 +15,7 @@ define('URL_TOKEN', "https://login.live.com/oauth20_token.srf?");
 define('URL_USER', "https://apis.live.net/v5.0/me?");
 # END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
 
-// remember the user's last url so we can redirect them back to there after the login ends:
-if (!$_SESSION['WPOA']['LAST_URL']) {$_SESSION['WPOA']['LAST_URL'] = strtok($_SERVER['HTTP_REFERER'], "?");}
+WPOA_Session::save_last_url();
 
 # AUTHENTICATION FLOW #
 // the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
@@ -40,7 +36,7 @@ elseif (isset($_GET['error_message'])) {
 }
 elseif (isset($_GET['code'])) {
 	// post-auth phase, verify the state:
-	if ($_SESSION['WPOA']['STATE'] == $_GET['state']) {
+	if (WPOA_Session::get_state() == $_GET['state']) {
 		// get an access token from the third party provider:
 		get_oauth_token($this);
 		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
@@ -55,7 +51,7 @@ elseif (isset($_GET['code'])) {
 }
 else {
 	// pre-auth, start the auth process:
-	if ((empty($_SESSION['WPOA']['EXPIRES_AT'])) || (time() > $_SESSION['WPOA']['EXPIRES_AT'])) {
+	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
 		// expired token; clear the state:
 		$this->wpoa_clear_login_state();
 	}
@@ -74,7 +70,7 @@ function get_oauth_code($wpoa) {
 		'state' => uniqid('', true),
 		'redirect_uri' => REDIRECT_URI,
 	);
-	$_SESSION['WPOA']['STATE'] = $params['state'];
+	WPOA_Session::set_state($params['state']);
 	$url = URL_AUTH . http_build_query($params);
 	header("Location: $url");
 	exit;
@@ -130,9 +126,9 @@ function get_oauth_token($wpoa) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
 	}
 	else {
-		$_SESSION['WPOA']['ACCESS_TOKEN'] = $access_token;
-		$_SESSION['WPOA']['EXPIRES_IN'] = $expires_in;
-		$_SESSION['WPOA']['EXPIRES_AT'] = $expires_at;
+		WPOA_Session::set_token($access_token);
+		WPOA_Session::set_expires_in($expires_in);
+		WPOA_Session::set_expires_at($expires_at);
 		return true;
 	}
 }
@@ -141,7 +137,7 @@ function get_oauth_identity($wpoa) {
 	// here we exchange the access token for the user info...
 	// set the access token param:
 	$params = array(
-		'access_token' => $_SESSION['WPOA']['ACCESS_TOKEN'], // PROVIDER SPECIFIC: the access token is passed to Windows Live using this key name
+		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access_token is passed to Google via POST param
 	);
 	$url_params = http_build_query($params);
 	// perform the http request:
@@ -162,8 +158,8 @@ function get_oauth_identity($wpoa) {
 			$opts = array('http' =>
 				array(
 					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github requires User-Agent here...
-					'header'  => "Authorization: Bearer " . $_SESSION['WPOA']['ACCESS_TOKEN'] . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
+					// PROVIDER NORMALIZATION: Reddit/Github User-Agent
+					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
 				)
 			);
 			$context = $context  = stream_context_create($opts);
@@ -176,7 +172,7 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = $_SESSION['WPOA']['PROVIDER'];
+	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
 	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Windows Live returns the user's unique id
 	//$oauth_identity[WPOA_Session::USER_NAME] = 'not_provided'; // PROVIDER SPECIFIC: Windows Live never provides the user's email!
 	if (!$oauth_identity[WPOA_Session::USER_ID]) {

--- a/login-windowslive.php
+++ b/login-windowslive.php
@@ -176,10 +176,10 @@ function get_oauth_identity($wpoa) {
 	}
 	// parse and return the user's oauth identity:
 	$oauth_identity = array();
-	$oauth_identity['provider'] = $_SESSION['WPOA']['PROVIDER'];
-	$oauth_identity['id'] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Windows Live returns the user's unique id
-	//$oauth_identity['email'] = 'not_provided'; // PROVIDER SPECIFIC: Windows Live never provides the user's email!
-	if (!$oauth_identity['id']) {
+	$oauth_identity[WPOA_Session::PROVIDER] = $_SESSION['WPOA']['PROVIDER'];
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Windows Live returns the user's unique id
+	//$oauth_identity[WPOA_Session::USER_NAME] = 'not_provided'; // PROVIDER SPECIFIC: Windows Live never provides the user's email!
+	if (!$oauth_identity[WPOA_Session::USER_ID]) {
 		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
 	}
 	return $oauth_identity;

--- a/login-windowslive.php
+++ b/login-windowslive.php
@@ -6,40 +6,40 @@ include_once 'login-common.php';
 error_reporting(E_ALL | E_STRICT);
 
 class LoginWindowsLive extends AbstractLoginCommon {
-	public function __construct($wpoa) {
-		parent::__construct('Windows Live', 
-			"https://login.microsoftonline.com/common/oauth2/v2.0/authorize?", 
-			"https://login.microsoftonline.com/common/oauth2/v2.0/token", 
-			"https://outlook.office.com/api/v2.0/me?",
-			$wpoa);
-		$this->useBearer = true;
-	}
+    public function __construct($wpoa) {
+        parent::__construct('Windows Live',
+                "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?",
+                "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+                "https://outlook.office.com/api/v2.0/me?",
+                $wpoa);
+        $this->useBearer = true;
+    }
 
-	
-  function getOAuthCodeExtendArray($array){
-	  // TODO : There is certainly another scope where to retrieve only user name and email...
-	  $array['scope'] = 'https://outlook.office.com/contacts.read';
-	  return $array;
-  }
 
-  function getOAuthTokenExtendArray($array) {
-	  return $array;
-  }
-  
-  function getOAuthIdentityParameters(){
-	$params = array(
-		'api-version' => "1.6",
-	);
-	return array();
-  }
-  
-  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['Id'];
-	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['DisplayName'];
-	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['EmailAddress'];
+    function getOAuthCodeExtendArray($array){
+        // TODO : There is certainly another scope where to retrieve only user name and email...
+        $array['scope'] = 'https://outlook.office.com/contacts.read';
+        return $array;
+    }
 
-	return $oauth_identity;
-  }
+    function getOAuthTokenExtendArray($array) {
+        return $array;
+    }
+
+    function getOAuthIdentityParameters(){
+        $params = array(
+                'api-version' => "1.6",
+                );
+        return array();
+    }
+
+    function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+        $oauth_identity[WPOA_Session::USER_ID] = $result_obj['Id'];
+        $oauth_identity[WPOA_Session::USER_NAME] = $result_obj['DisplayName'];
+        $oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['EmailAddress'];
+
+        return $oauth_identity;
+    }
 }
 
 $login = new LoginWindowsLive($this);

--- a/login-windowslive.php
+++ b/login-windowslive.php
@@ -1,184 +1,46 @@
 <?php
 
 include_once 'session.php';
+include_once 'login-common.php';
 
-# DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
-WPOA_Session::set_provider('Windows Live');
-define('HTTP_UTIL', get_option('wpoa_http_util'));
-define('CLIENT_ENABLED', get_option('wpoa_windowslive_api_enabled'));
-define('CLIENT_ID', get_option('wpoa_windowslive_api_id'));
-define('CLIENT_SECRET', get_option('wpoa_windowslive_api_secret'));
-define('REDIRECT_URI', rtrim(site_url(), '/') . '/');
-define('SCOPE', 'wl.basic'); // PROVIDER SPECIFIC: 'wl.basic' is the minimum scope required to get the user's id from Windows Live
-define('URL_AUTH', "https://login.live.com/oauth20_authorize.srf?");
-define('URL_TOKEN', "https://login.live.com/oauth20_token.srf?");
-define('URL_USER', "https://apis.live.net/v5.0/me?");
-# END OF DEFINE THE OAUTH PROVIDER AND SETTINGS TO USE #
+error_reporting(E_ALL | E_STRICT);
 
-WPOA_Session::save_last_url();
-
-# AUTHENTICATION FLOW #
-// the oauth 2.0 authentication flow will start in this script and make several calls to the third-party authentication provider which in turn will make callbacks to this script that we continue to handle until the login completes with a success or failure:
-if (!CLIENT_ENABLED) {
-	$this->wpoa_end_login("This third-party authentication provider has not been enabled. Please notify the admin or try again later.");
-}
-elseif (!CLIENT_ID || !CLIENT_SECRET) {
-	// do not proceed if id or secret is null:
-	$this->wpoa_end_login("This third-party authentication provider has not been configured with an API key/secret. Please notify the admin or try again later.");
-}
-elseif (isset($_GET['error_description'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_description']);
-}
-elseif (isset($_GET['error_message'])) {
-	// do not proceed if an error was detected:
-	$this->wpoa_end_login($_GET['error_message']);
-}
-elseif (isset($_GET['code'])) {
-	// post-auth phase, verify the state:
-	if (WPOA_Session::get_state() == $_GET['state']) {
-		// get an access token from the third party provider:
-		get_oauth_token($this);
-		// get the user's third-party identity and attempt to login/register a matching wordpress user account:
-		$oauth_identity = get_oauth_identity($this);
-		$this->wpoa_login_user($oauth_identity);
+class LoginWindowsLive extends AbstractLoginCommon {
+	public function __construct($wpoa) {
+		parent::__construct('Windows Live', 
+			"https://login.microsoftonline.com/common/oauth2/v2.0/authorize?", 
+			"https://login.microsoftonline.com/common/oauth2/v2.0/token", 
+			"https://outlook.office.com/api/v2.0/me?",
+			$wpoa);
+		$this->useBearer = true;
 	}
-	else {
-		// possible CSRF attack, end the login with a generic message to the user and a detailed message to the admin/logs in case of abuse:
-		// TODO: report detailed message to admin/logs here...
-		$this->wpoa_end_login("Sorry, we couldn't log you in. Please notify the admin or try again later.");
-	}
-}
-else {
-	// pre-auth, start the auth process:
-	if ((empty(WPOA_Session::get_expires_at())) || (time() > WPOA_Session::get_expires_at())) {
-		// expired token; clear the state:
-		$this->wpoa_clear_login_state();
-	}
-	get_oauth_code($this);
-}
-// we shouldn't be here, but just in case...
-$this->wpoa_end_login("Sorry, we couldn't log you in. The authentication flow terminated in an unexpected way. Please notify the admin or try again later.");
-# END OF AUTHENTICATION FLOW #
 
-# AUTHENTICATION FLOW HELPER FUNCTIONS #
-function get_oauth_code($wpoa) {
+	
+  function getOAuthCodeExtendArray($array){
+	  // TODO : There is certainly another scope where to retrieve only user name and email...
+	  $array['scope'] = 'https://outlook.office.com/contacts.read';
+	  return $array;
+  }
+
+  function getOAuthTokenExtendArray($array) {
+	  return $array;
+  }
+  
+  function getOAuthIdentityParameters(){
 	$params = array(
-		'response_type' => 'code',
-		'client_id' => CLIENT_ID,
-		'scope' => SCOPE,
-		'state' => uniqid('', true),
-		'redirect_uri' => REDIRECT_URI,
+		'api-version' => "1.6",
 	);
-	WPOA_Session::set_state($params['state']);
-	$url = URL_AUTH . http_build_query($params);
-	header("Location: $url");
-	exit;
-}
+	return array();
+  }
+  
+  function getOAuthIdentityFillArray($result_obj, $oauth_identity){
+	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['Id'];
+	$oauth_identity[WPOA_Session::USER_NAME] = $result_obj['DisplayName'];
+	$oauth_identity[WPOA_Session::USER_EMAIL] = $result_obj['EmailAddress'];
 
-function get_oauth_token($wpoa) {
-	$params = array(
-		'grant_type' => 'authorization_code',
-		'client_id' => CLIENT_ID,
-		'client_secret' => CLIENT_SECRET,
-		'code' => $_GET['code'],
-		'redirect_uri' => REDIRECT_URI,
-	);
-	$url_params = http_build_query($params);
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = URL_TOKEN . $url_params;
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($curl, CURLOPT_POST, 1);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $url_params); // TODO: for Google we use $params...
-			// PROVIDER NORMALIZATION: Reddit requires sending a User-Agent header...
-			// PROVIDER NORMALIZATION: Reddit requires sending the client id/secret via http basic authentication...
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, (get_option('wpoa_http_util_verify_ssl') == 1 ? 1 : 0));
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, (get_option('wpoa_http_util_verify_ssl') == 1 ? 2 : 0));
-			$result = curl_exec($curl);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_TOKEN, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'POST',
-					'header'  => 'Content-type: application/x-www-form-urlencoded',
-					'content' => $url_params,
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve access token via stream context. Please notify the admin or try again later.");
-			}
-			break;
-	}
-	// parse the result:
-	$result_obj = json_decode($result, true); // PROVIDER SPECIFIC: Windows Live encodes the access token result as json by default
-	$access_token = $result_obj['access_token']; // PROVIDER SPECIFIC: this is how Windows Live returns the access token KEEP THIS PROTECTED!
-	$expires_in = $result_obj['expires_in']; // PROVIDER SPECIFIC: this is how Windows Live returns the access token's expiration
-	$expires_at = time() + $expires_in;
-	// handle the result:
-	if (!$access_token || !$expires_in) {
-		// malformed access token result detected:
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Malformed access token result detected. Please notify the admin or try again later.");
-	}
-	else {
-		WPOA_Session::set_token($access_token);
-		WPOA_Session::set_expires_in($expires_in);
-		WPOA_Session::set_expires_at($expires_at);
-		return true;
-	}
-}
-
-function get_oauth_identity($wpoa) {
-	// here we exchange the access token for the user info...
-	// set the access token param:
-	$params = array(
-		'access_token' => WPOA_Session::get_token(), // PROVIDER SPECIFIC: the access_token is passed to Google via POST param
-	);
-	$url_params = http_build_query($params);
-	// perform the http request:
-	switch (strtolower(HTTP_UTIL)) {
-		case 'curl':
-			$url = rtrim(URL_USER, "?");
-			$curl = curl_init();
-			curl_setopt($curl, CURLOPT_URL, $url);
-			curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']); // TODO: does Windows Live require this?
-			curl_setopt($curl, CURLOPT_HTTPHEADER, array("Authorization: bearer " . $_SESSION['WPOA']['ACCESS_TOKEN'])); // PROVIDER SPECIFIC: do we have to do this for Windows Live?
-			//curl_setopt($curl, CURLOPT_HTTPHEADER, array('x-li-format: json')); // PROVIDER SPECIFIC: I think this is only for LinkedIn...
-			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-			$result = curl_exec($curl);
-			$result_obj = json_decode($result, true);
-			break;
-		case 'stream-context':
-			$url = rtrim(URL_USER, "?");
-			$opts = array('http' =>
-				array(
-					'method'  => 'GET',
-					// PROVIDER NORMALIZATION: Reddit/Github User-Agent
-					'header'  => "Authorization: Bearer " . WPOA_Session::get_token() . "\r\n" . "x-li-format: json\r\n", // PROVIDER SPECIFIC: i think only LinkedIn uses x-li-format...
-				)
-			);
-			$context = $context  = stream_context_create($opts);
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false) {
-				$wpoa->wpoa_end_login("Sorry, we couldn't log you in. Could not retrieve user identity via stream context. Please notify the admin or try again later.");
-			}
-			$result_obj = json_decode($result, true);
-			break;
-	}
-	// parse and return the user's oauth identity:
-	$oauth_identity = array();
-	$oauth_identity[WPOA_Session::PROVIDER] = WPOA_Session::get_provider();
-	$oauth_identity[WPOA_Session::USER_ID] = $result_obj['id']; // PROVIDER SPECIFIC: this is how Windows Live returns the user's unique id
-	//$oauth_identity[WPOA_Session::USER_NAME] = 'not_provided'; // PROVIDER SPECIFIC: Windows Live never provides the user's email!
-	if (!$oauth_identity[WPOA_Session::USER_ID]) {
-		$wpoa->wpoa_end_login("Sorry, we couldn't log you in. User identity was not found. Please notify the admin or try again later.");
-	}
 	return $oauth_identity;
+  }
 }
-# END OF AUTHENTICATION FLOW HELPER FUNCTIONS #
-?>
+
+$login = new LoginWindowsLive($this);
+$login->run();

--- a/register.php
+++ b/register.php
@@ -9,8 +9,8 @@ global $wpdb;
 // initiate the user session:
 session_start();
 
-$logger->log("Register : Id = " . WPOA_Session::get_id());
-$logger->dump($oauth_identity);
+Logger::Instance()->log("Register : Id = " . WPOA_Session::get_id());
+Logger::Instance()->dump($oauth_identity);
 
 // prevent users from registering if the option is turned off in the dashboard:
 if (!get_option("users_can_register")) {
@@ -20,22 +20,22 @@ if (!get_option("users_can_register")) {
 if (array_key_exists(WPOA_Session::USER_NAME, $oauth_identity)) {
 	$username = $oauth_identity[WPOA_Session::USER_NAME];
 } else {
-	$logger->log("Register : User name not set, using it from post");
+	Logger::Instance()->log("Register : User name not set, using it from post");
 	$username = $_POST['identity'];
 }
 
 if (array_key_exists(WPOA_Session::USER_EMAIL, $oauth_identity)) {
 	$email = $oauth_identity[WPOA_Session::USER_EMAIL];
 } else {
-	$logger->log("Register : Email not set, using it from post");
+	Logger::Instance()->log("Register : Email not set, using it from post");
 	$email = $_POST['identity'];
 }
 
 $password = wp_generate_password();
 
-$logger->log("Register : Username = " . $username);
-$logger->log("Register : Password = " . $password);
-$logger->log("Register : Email = " . $email);
+Logger::Instance()->log("Register : Username = " . $username);
+Logger::Instance()->log("Register : Password = " . $password);
+Logger::Instance()->log("Register : Email = " . $email);
 
 
 
@@ -58,7 +58,7 @@ $update_role_result = wp_update_user(array('ID' => $user_id, 'role' => $role));
 
 // proceed if no errors were detected:
 if ($update_username_result == false) {
-	$logger->log("Register : username = " . $update_username_result . " / nickname = " . $update_nickname_result);
+	Logger::Instance()->log("Register : username = " . $update_username_result . " / nickname = " . $update_nickname_result);
 	$this->fail("Could not rename the username during registration. Please contact an admin or try again later.");
 }
 elseif ($update_role_result == false) {

--- a/register.php
+++ b/register.php
@@ -1,1 +1,86 @@
-<?php// TODO: very important that we sanitize all $_POST variables here before using them!// TODO: this doesn't call wpoa_end_login() which might result in the LAST_URL not being cleared...global $wpdb;// initiate the user session:session_start();// prevent users from registering if the option is turned off in the dashboard:if (!get_option("users_can_register")) {	$_SESSION["WPOA"]["RESULT"] = "Sorry, user registration is disabled at this time. Your account could not be registered. Please notify the admin or try again later.";	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]);	exit;}// registration was initiated from an oauth provider, set the username and password automatically.if ($_SESSION["WPOA"]["USER_ID"] != "") {	$username = uniqid('', true);	$password = wp_generate_password();}// registration was initiated from the standard sign up form, set the username and password that was requested by the user.if ( $_SESSION["WPOA"]["USER_ID"] == "" ) {	// this registration was initiated from the standard Registration page, create account and login the user automatically	$username = $_POST['identity'];	$password = $_POST['password'];}// now attempt to generate the user and get the user id:$user_id = wp_create_user( $username, $password, $username ); // we use wp_create_user instead of wp_insert_user so we can handle the error when the user being registered already exists// check if the user was actually created:if (is_wp_error($user_id)) {	// there was an error during registration, redirect and notify the user:	$_SESSION["WPOA"]["RESULT"] = $user_id->get_error_message();	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]);	exit;}// now try to update the username to something more permanent and recognizable:$username = "user" . $user_id;$update_username_result = $wpdb->update($wpdb->users, array('user_login' => $username, 'user_nicename' => $username, 'display_name' => $username), array('ID' => $user_id));$update_nickname_result = update_user_meta($user_id, 'nickname', $username);// apply the custom default user role:$role = get_option('wpoa_new_user_role');$update_role_result = wp_update_user(array('ID' => $user_id, 'role' => $role));// proceed if no errors were detected:if ($update_username_result == false || $update_nickname_result == false) {	// there was an error during registration, redirect and notify the user:	$_SESSION["WPOA"]["RESULT"] = "Could not rename the username during registration. Please contact an admin or try again later.";	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;}elseif ($update_role_result == false) {	// there was an error during registration, redirect and notify the user:	$_SESSION["WPOA"]["RESULT"] = "Could not assign default user role during registration. Please contact an admin or try again later.";	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;}else {	// registration was successful, the user account was created, proceed to login the user automatically...	// associate the wordpress user account with the now-authenticated third party account:	$this->wpoa_link_account($user_id);	// attempt to login the new user (this could be error prone):	$creds = array();	$creds['user_login'] = $username;	$creds['user_password'] = $password;	$creds['remember'] = true;	$user = wp_signon( $creds, false );	// send a notification e-mail to the admin and the new user (we can also build our own email if necessary):	if (!get_option('wpoa_suppress_welcome_email')) {		//wp_mail($username, "New User Registration", "Thank you for registering!\r\nYour username: " . $username . "\r\nYour password: " . $password, $headers);		wp_new_user_notification( $user_id, $password );	}	// finally redirect the user back to the page they were on and notify them of successful registration:	$_SESSION["WPOA"]["RESULT"] = "You have been registered successfully!";	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;}?>
+<?php
+
+// TODO: very important that we sanitize all $_POST variables here before using them!
+// TODO: this doesn't call wpoa_end_login() which might result in the LAST_URL not being cleared...
+include_once 'session.php';
+
+global $wpdb;
+
+// initiate the user session:
+session_start();
+
+$logger->log("Register : Id = " . WPOA_Session::get_id());
+$logger->dump($oauth_identity);
+
+// prevent users from registering if the option is turned off in the dashboard:
+if (!get_option("users_can_register")) {
+	$this->fail("Sorry, user registration is disabled at this time. Your account could not be registered. Please notify the admin or try again later.");
+}
+
+if (array_key_exists(WPOA_Session::USER_NAME, $oauth_identity)) {
+	$username = $oauth_identity[WPOA_Session::USER_NAME];
+} else {
+	$logger->log("Register : User name not set, using it from post");
+	$username = $_POST['identity'];
+}
+
+if (array_key_exists(WPOA_Session::USER_EMAIL, $oauth_identity)) {
+	$email = $oauth_identity[WPOA_Session::USER_EMAIL];
+} else {
+	$logger->log("Register : Email not set, using it from post");
+	$email = $_POST['identity'];
+}
+
+$password = wp_generate_password();
+
+$logger->log("Register : Username = " . $username);
+$logger->log("Register : Password = " . $password);
+$logger->log("Register : Email = " . $email);
+
+
+
+// now attempt to generate the user and get the user id:
+$user_id = wp_create_user($username, $password, $email); // we use wp_create_user instead of wp_insert_user so we can handle the error when the user being registered already exists
+
+// check if the user was actually created:
+if (is_wp_error($user_id)) {
+	// there was an error during registration, redirect and notify the user:
+	$error = $user_id->get_error_message();
+	$this->fail($error);
+}
+
+// now try to update the username to something more permanent and recognizable:
+$update_username_result = $wpdb->update($wpdb->users, array('user_login' => $email, 'user_nicename' => $username, 'display_name' => $username), array('ID' => $user_id));
+
+// apply the custom default user role:
+$role = get_option('wpoa_new_user_role');
+$update_role_result = wp_update_user(array('ID' => $user_id, 'role' => $role));
+
+// proceed if no errors were detected:
+if ($update_username_result == false) {
+	$logger->log("Register : username = " . $update_username_result . " / nickname = " . $update_nickname_result);
+	$this->fail("Could not rename the username during registration. Please contact an admin or try again later.");
+}
+elseif ($update_role_result == false) {
+	$this->fail("Could not assign default user role during registration. Please contact an admin or try again later.");	
+}
+else {
+	// registration was successful, the user account was created, proceed to login the user automatically...
+	// associate the wordpress user account with the now-authenticated third party account:
+	$this->wpoa_link_account($user_id);
+	// attempt to login the new user (this could be error prone):
+	$creds = array();
+	$creds['user_login'] = $username;
+	$creds['user_password'] = $password;
+	$creds['remember'] = true;
+	$user = wp_signon( $creds, false );
+	// send a notification e-mail to the admin and the new user (we can also build our own email if necessary):
+	if (!get_option('wpoa_suppress_welcome_email')) {
+		//wp_mail($username, "New User Registration", "Thank you for registering!\r\nYour username: " . $username . "\r\nYour password: " . $password, $headers);
+		wp_new_user_notification( $user_id, $password );
+	}
+	// finally redirect the user back to the page they were on and notify them of successful registration:
+	WPOA_Session::set_result("You have been registered successfully!");
+	header("Location: " . WPOA_Session::get_last_url()); exit;
+}
+?>

--- a/register.php
+++ b/register.php
@@ -6,6 +6,10 @@ include_once 'session.php';
 
 global $wpdb;
 
+function IsNullOrEmptyString($question){
+    return (!isset($question) || trim($question)==='');
+}
+
 // initiate the user session:
 session_start();
 
@@ -29,6 +33,10 @@ if (array_key_exists(WPOA_Session::USER_EMAIL, $oauth_identity)) {
 } else {
 	Logger::Instance()->log("Register : Email not set, using it from post");
 	$email = $_POST['identity'];
+}
+
+if (IsNullOrEmptyString($username)) {
+    $username = $email;
 }
 
 $password = wp_generate_password();

--- a/session.php
+++ b/session.php
@@ -3,6 +3,11 @@
 include_once "logger.php";
 
 class WPOA_Session {
+    const PROVIDER = 'provider';
+    const USER_ID = 'user_id';
+    const USER_NAME = 'user_name';
+    const USER_EMAIL = 'user_email';
+    
     public static function start()
     {
         session_start();    
@@ -71,13 +76,11 @@ class WPOA_Session {
     }
 
     public static function save_last_url() {
-        // try to obtain the redirect_url from the default login page:
+        // try to obtain the redirect_url from the default login page. If no one exists, then get user's last page
 	    $redirect_url = esc_url($_GET['redirect_to']);
-	    // if no redirect_url was found, set it to the user's last page:
 	    if (!$redirect_url) {
     		$redirect_url = strtok($_SERVER['HTTP_REFERER'], "?");
     	}
-    	// set the user's last page so we can return that user there after they login:
     	$_SESSION['WPOA']['LAST_URL'] = $redirect_url;
     }
 
@@ -102,7 +105,6 @@ class WPOA_Session {
    
     public static function clear() {
         $logger->log("SESSION : Clearing session");
-        // print_stack_trace();
         unset($_SESSION["WPOA"]["PROVIDER"]);
         unset($_SESSION["WPOA"]["USER_ID"]);
 		unset($_SESSION["WPOA"]["USER_EMAIL"]);

--- a/session.php
+++ b/session.php
@@ -25,13 +25,66 @@ class WPOA_Session {
         start();
         $_SESSION['WPOA']['PROVIDER'] = $value;
     }
+    
+    public static function get_email() {
+        return $_SESSION['WPOA']['USER_EMAIL'];
+    }
 
+    public static function set_email($value) {
+        start();
+        $_SESSION['WPOA']['USER_EMAIL'] = $value;
+    }
+
+    public static function get_token() {
+        return $_SESSION['WPOA']['ACCESS_TOKEN'];
+    }
+
+    public static function set_token($value) {
+        start();
+        $_SESSION['WPOA']['ACCESS_TOKEN'] = $value;
+    }
+    
+    public static function get_expires_in() {
+        return $_SESSION['WPOA']['EXPIRES_IN'];
+    }
+
+    public static function set_expires_in($value) {
+        start();
+        $_SESSION['WPOA']['EXPIRES_IN'] = $value;
+    }
+    
+    public static function get_expires_at() {
+        return $_SESSION['WPOA']['EXPIRES_AT'];
+    }
+
+    public static function set_expires_at($value) {
+        start();
+        $_SESSION['WPOA']['EXPIRES_AT'] = $value;
+    }
+   
+    public static function get_last_url() {
+        return $_SESSION['WPOA']['LAST_URL'];
+    }
+
+    public static function save_last_url() {
+        start();
+        // try to obtain the redirect_url from the default login page:
+	    $redirect_url = esc_url($_GET['redirect_to']);
+	    // if no redirect_url was found, set it to the user's last page:
+	    if (!$redirect_url) {
+    		$redirect_url = strtok($_SERVER['HTTP_REFERER'], "?");
+    	}
+    	// set the user's last page so we can return that user there after they login:
+    	$_SESSION['WPOA']['LAST_URL'] = $redirect_url;
+    }
+   
     public static function clear() {
+        unset($_SESSION["WPOA"]["PROVIDER"]);
         unset($_SESSION["WPOA"]["USER_ID"]);
 		unset($_SESSION["WPOA"]["USER_EMAIL"]);
 		unset($_SESSION["WPOA"]["ACCESS_TOKEN"]);
 		unset($_SESSION["WPOA"]["EXPIRES_IN"]);
 		unset($_SESSION["WPOA"]["EXPIRES_AT"]);
-		//unset($_SESSION["WPOA"]["LAST_URL"]);
+		unset($_SESSION["WPOA"]["LAST_URL"]);
     }
 }

--- a/session.php
+++ b/session.php
@@ -1,0 +1,37 @@
+<?php
+
+class WPOA_Session {
+    public static function start()
+    {
+        if (!isset($_SESSION)) {
+            session_start();
+        }
+    }
+
+    public static function get_id() {
+        return $_SESSION['WPOA']['USER_ID'];
+    }
+
+    public static function set_id($value) {
+        start();
+        $_SESSION['WPOA']['USER_ID'] = $value;
+    }
+
+    public static function get_provider() {
+        return $_SESSION['WPOA']['PROVIDER'];
+    }
+
+    public static function set_provider($value) {
+        start();
+        $_SESSION['WPOA']['PROVIDER'] = $value;
+    }
+
+    public static function clear() {
+        unset($_SESSION["WPOA"]["USER_ID"]);
+		unset($_SESSION["WPOA"]["USER_EMAIL"]);
+		unset($_SESSION["WPOA"]["ACCESS_TOKEN"]);
+		unset($_SESSION["WPOA"]["EXPIRES_IN"]);
+		unset($_SESSION["WPOA"]["EXPIRES_AT"]);
+		//unset($_SESSION["WPOA"]["LAST_URL"]);
+    }
+}

--- a/session.php
+++ b/session.php
@@ -1,11 +1,12 @@
 <?php
 
+include_once "logger.php";
+
 class WPOA_Session {
     public static function start()
     {
-        if (!isset($_SESSION)) {
-            session_start();
-        }
+        session_start();    
+        $logger->dump($_SESSION);
     }
 
     public static function get_id() {
@@ -13,7 +14,6 @@ class WPOA_Session {
     }
 
     public static function set_id($value) {
-        start();
         $_SESSION['WPOA']['USER_ID'] = $value;
     }
 
@@ -22,7 +22,6 @@ class WPOA_Session {
     }
 
     public static function set_provider($value) {
-        start();
         $_SESSION['WPOA']['PROVIDER'] = $value;
     }
     
@@ -31,7 +30,6 @@ class WPOA_Session {
     }
 
     public static function set_email($value) {
-        start();
         $_SESSION['WPOA']['USER_EMAIL'] = $value;
     }
 
@@ -40,7 +38,6 @@ class WPOA_Session {
     }
 
     public static function set_token($value) {
-        start();
         $_SESSION['WPOA']['ACCESS_TOKEN'] = $value;
     }
     
@@ -49,7 +46,6 @@ class WPOA_Session {
     }
 
     public static function set_expires_in($value) {
-        start();
         $_SESSION['WPOA']['EXPIRES_IN'] = $value;
     }
     
@@ -58,7 +54,6 @@ class WPOA_Session {
     }
 
     public static function set_expires_at($value) {
-        start();
         $_SESSION['WPOA']['EXPIRES_AT'] = $value;
     }
    
@@ -66,8 +61,16 @@ class WPOA_Session {
         return $_SESSION['WPOA']['LAST_URL'];
     }
 
+    
+    public static function set_last_url($value) {
+        $_SESSION['WPOA']['LAST_URL'] = $value;
+    }
+
+    public static function clear_last_url() {
+        unset($_SESSION["WPOA"]["LAST_URL"]);
+    }
+
     public static function save_last_url() {
-        start();
         // try to obtain the redirect_url from the default login page:
 	    $redirect_url = esc_url($_GET['redirect_to']);
 	    // if no redirect_url was found, set it to the user's last page:
@@ -77,8 +80,29 @@ class WPOA_Session {
     	// set the user's last page so we can return that user there after they login:
     	$_SESSION['WPOA']['LAST_URL'] = $redirect_url;
     }
+
+    public static function get_result() {
+        return $_SESSION["WPOA"]["RESULT"];
+    }
+
+    public static function set_result($value) {
+        $logger->log("SESSION : Set_result = " . $value);
+        $_SESSION["WPOA"]["RESULT"] = $value;
+    }
+
+    
+    public static function get_state() {
+        return $_SESSION['WPOA']['STATE'];
+    }
+
+    public static function set_state($value) {
+        $_SESSION['WPOA']['STATE'] = $value;
+    }
+    
    
     public static function clear() {
+        $logger->log("SESSION : Clearing session");
+        // print_stack_trace();
         unset($_SESSION["WPOA"]["PROVIDER"]);
         unset($_SESSION["WPOA"]["USER_ID"]);
 		unset($_SESSION["WPOA"]["USER_EMAIL"]);
@@ -86,5 +110,9 @@ class WPOA_Session {
 		unset($_SESSION["WPOA"]["EXPIRES_IN"]);
 		unset($_SESSION["WPOA"]["EXPIRES_AT"]);
 		unset($_SESSION["WPOA"]["LAST_URL"]);
+        unset($_SESSION["WPOA"]["RESULT"]);
+        unset($_SESSION['WPOA']['STATE']);
     }
 }
+
+WPOA_Session::start();

--- a/session.php
+++ b/session.php
@@ -11,7 +11,7 @@ class WPOA_Session {
     public static function start()
     {
         session_start();    
-        $logger->dump($_SESSION);
+        Logger::Instance()->dump($_SESSION);
     }
 
     public static function get_id() {
@@ -89,7 +89,7 @@ class WPOA_Session {
     }
 
     public static function set_result($value) {
-        $logger->log("SESSION : Set_result = " . $value);
+        Logger::Instance()->log("SESSION : Set_result = " . $value);
         $_SESSION["WPOA"]["RESULT"] = $value;
     }
 
@@ -104,7 +104,7 @@ class WPOA_Session {
     
    
     public static function clear() {
-        $logger->log("SESSION : Clearing session");
+        Logger::Instance()->log("SESSION : Clearing session");
         unset($_SESSION["WPOA"]["PROVIDER"]);
         unset($_SESSION["WPOA"]["USER_ID"]);
 		unset($_SESSION["WPOA"]["USER_EMAIL"]);

--- a/session.php
+++ b/session.php
@@ -7,10 +7,10 @@ class WPOA_Session {
     const USER_ID = 'user_id';
     const USER_NAME = 'user_name';
     const USER_EMAIL = 'user_email';
-    
+
     public static function start()
     {
-        session_start();    
+        session_start();
         Logger::Instance()->dump($_SESSION);
     }
 
@@ -29,7 +29,7 @@ class WPOA_Session {
     public static function set_provider($value) {
         $_SESSION['WPOA']['PROVIDER'] = $value;
     }
-    
+
     public static function get_email() {
         return $_SESSION['WPOA']['USER_EMAIL'];
     }
@@ -45,7 +45,7 @@ class WPOA_Session {
     public static function set_token($value) {
         $_SESSION['WPOA']['ACCESS_TOKEN'] = $value;
     }
-    
+
     public static function get_expires_in() {
         return $_SESSION['WPOA']['EXPIRES_IN'];
     }
@@ -53,7 +53,7 @@ class WPOA_Session {
     public static function set_expires_in($value) {
         $_SESSION['WPOA']['EXPIRES_IN'] = $value;
     }
-    
+
     public static function get_expires_at() {
         return $_SESSION['WPOA']['EXPIRES_AT'];
     }
@@ -61,12 +61,12 @@ class WPOA_Session {
     public static function set_expires_at($value) {
         $_SESSION['WPOA']['EXPIRES_AT'] = $value;
     }
-   
+
     public static function get_last_url() {
         return $_SESSION['WPOA']['LAST_URL'];
     }
 
-    
+
     public static function set_last_url($value) {
         $_SESSION['WPOA']['LAST_URL'] = $value;
     }
@@ -77,11 +77,11 @@ class WPOA_Session {
 
     public static function save_last_url() {
         // try to obtain the redirect_url from the default login page. If no one exists, then get user's last page
-	    $redirect_url = esc_url($_GET['redirect_to']);
-	    if (!$redirect_url) {
-    		$redirect_url = strtok($_SERVER['HTTP_REFERER'], "?");
-    	}
-    	$_SESSION['WPOA']['LAST_URL'] = $redirect_url;
+        $redirect_url = esc_url($_GET['redirect_to']);
+        if (!$redirect_url) {
+            $redirect_url = strtok($_SERVER['HTTP_REFERER'], "?");
+        }
+        $_SESSION['WPOA']['LAST_URL'] = $redirect_url;
     }
 
     public static function get_result() {
@@ -93,7 +93,7 @@ class WPOA_Session {
         $_SESSION["WPOA"]["RESULT"] = $value;
     }
 
-    
+
     public static function get_state() {
         return $_SESSION['WPOA']['STATE'];
     }
@@ -101,17 +101,17 @@ class WPOA_Session {
     public static function set_state($value) {
         $_SESSION['WPOA']['STATE'] = $value;
     }
-    
-   
+
+
     public static function clear() {
         Logger::Instance()->log("SESSION : Clearing session");
         unset($_SESSION["WPOA"]["PROVIDER"]);
         unset($_SESSION["WPOA"]["USER_ID"]);
-		unset($_SESSION["WPOA"]["USER_EMAIL"]);
-		unset($_SESSION["WPOA"]["ACCESS_TOKEN"]);
-		unset($_SESSION["WPOA"]["EXPIRES_IN"]);
-		unset($_SESSION["WPOA"]["EXPIRES_AT"]);
-		unset($_SESSION["WPOA"]["LAST_URL"]);
+        unset($_SESSION["WPOA"]["USER_EMAIL"]);
+        unset($_SESSION["WPOA"]["ACCESS_TOKEN"]);
+        unset($_SESSION["WPOA"]["EXPIRES_IN"]);
+        unset($_SESSION["WPOA"]["EXPIRES_AT"]);
+        unset($_SESSION["WPOA"]["LAST_URL"]);
         unset($_SESSION["WPOA"]["RESULT"]);
         unset($_SESSION['WPOA']['STATE']);
     }

--- a/wp-oauth-settings.php
+++ b/wp-oauth-settings.php
@@ -72,33 +72,6 @@
 				<nav><ul><li><a href="https://wordpress.org/plugins/wp-oauth/" target="_blank">WP-OAuth at WordPress.org</a></li><li><a href="https://github.com/perrybutler/WP-OAuth" target="_blank">WP-OAuth at GitHub.com</a></li><li><a href="http://glassocean.net/wp-oauth-enhances-your-wordpress-login-and-registration/" target="_blank">WP-OAuth at GlassOcean.net</a></li></ul></nav>
 			</div>
 		</div>
-		<div id="wpoa-settings-section-news" class="wpoa-settings-section">
-			<h3>News</h3>
-			<div class='form-padding'>
-				<?php 
-				$rss = fetch_feed("http://glassocean.net/tag/wp-oauth/feed/");
-				if (!is_wp_error($rss)) {
-					$maxitems = $rss->get_item_quantity(5); 
-					$rss_items = $rss->get_items(0, $maxitems);
-				}
-				?>
-				<?php if ($maxitems == 0) : ?>
-					<p><?php _e("Sorry, news was inaccessible or does not exist.", 'my-text-domain' ); ?></p>
-				<?php else : ?>
-				<ul>
-					<?php foreach ($rss_items as $item) : ?>
-						<li>
-							<a href="<?php echo esc_url($item->get_permalink()); ?>"
-								title="<?php printf( __('Posted %s', 'my-text-domain'), $item->get_date('j F Y | g:i a') ); ?>"
-								target="_blank">
-								<?php echo esc_html($item->get_title()); ?>
-							</a>
-						</li>
-					<?php endforeach; ?>
-				</ul>
-				<?php endif; ?>
-			</div>
-		</div>
 		<div id="wpoa-settings-section-config-check" class="wpoa-settings-section">
 		<h3>Config Check</h3>
 			<div class='form-padding'>

--- a/wp-oauth-settings.php
+++ b/wp-oauth-settings.php
@@ -512,6 +512,14 @@
 					<input type='text' name='wpoa_google_api_secret' value='<?php echo get_option('wpoa_google_api_secret'); ?>' />
 				</td>
 				</tr>
+
+				<tr valign='top'>
+				<th scope='row'>Limit to following domains (for non gmail account) :</th>
+				<td>
+					<input type='text' name='wpoa_google_check_domain' value='<?php echo get_option('wpoa_google_check_domain'); ?>' />
+				</td>
+				</tr>
+			
 			</table> <!-- .form-table -->
 			<p>
 				<strong>Instructions:</strong>
@@ -521,6 +529,7 @@
 					<li>At Google, provide your site's homepage URL (<?php echo $blog_url; ?>) for the new Project's Redirect URI. Don't forget the trailing slash!</li>
 					<li>At Google, you must also configure the Consent Screen with your Email Address and Product Name. This is what Google will display to users when they are asked to grant access to your site/app.</li>
 					<li>Paste your Client ID/Secret provided by Google into the fields above, then click the Save all settings button.</li>
+					<li>If you use a corporate account, you can limit to your compagny by sessing the limit domain. If you have multiple domain, use coma for separation (ie: example.com, another-example.com)</li>
 				</ol>
 			</p>
 			<?php submit_button('Save all settings'); ?>
@@ -816,6 +825,50 @@
 					<li>At Windows Live, create a new App. This will enable your site to access the Windows Live API.</li>
 					<li>At Windows Live, provide your site's homepage URL (<?php echo $blog_url; ?>) for the new App's Redirect URI. Don't forget the trailing slash!</li>
 					<li>Paste your Client ID/Secret provided by Windows Live into the fields above, then click the Save all settings button.</li>
+				</ol>
+			</p>
+			<?php submit_button('Save all settings'); ?>
+			</div> <!-- .form-padding -->
+			</div> <!-- .wpoa-settings-section -->
+			<!-- END Login with Windows Live section -->
+
+			<!-- START Login with Windows Azure section -->
+			<div id="wpoa-settings-section-login-with-windowsAzure" class="wpoa-settings-section">
+			<h3>Login with Windows Azure or Office 365</h3>
+			<div class='form-padding'>
+			<table class='form-table'>
+				<tr valign='top'>
+				<th scope='row'>Enabled:</th>
+				<td>
+					<input type='checkbox' name='wpoa_windowsazure_api_enabled' value='1' <?php checked(get_option('wpoa_windowsazure_api_enabled') == 1); ?> />
+				</td>
+				</tr>
+				
+				<tr valign='top'>
+				<th scope='row'>Client ID:</th>
+				<td>
+					<input type='text' name='wpoa_windowsazure_api_id' value='<?php echo get_option('wpoa_windowsazure_api_id'); ?>' />
+				</td>
+				</tr>
+				 
+				<tr valign='top'>
+				<th scope='row'>Client Secret:</th>
+				<td>
+					<input type='text' name='wpoa_windowsazure_api_secret' value='<?php echo get_option('wpoa_windowsazure_api_secret'); ?>' />
+				</td>
+				</tr>
+
+				<tr valign='top'>
+				<th scope='row'>Tenant Id:</th>
+				<td>
+					<input type='text' name='wpoa_windowsazure_tenant_id' value='<?php echo get_option('wpoa_windowsazure_tenant_id'); ?>' />
+				</td>
+				</tr>
+			</table> <!-- .form-table -->
+			<p>
+				<strong>Instructions:</strong>
+				<ol>
+					<li>Follow <b>Register your application with your AD tenant</b> section : <a target="_blank" href="https://azure.microsoft.com/en-us/documentation/articles/active-directory-protocols-oauth-code/">https://azure.microsoft.com/en-us/documentation/articles/active-directory-protocols-oauth-code/</a>.</li>
 				</ol>
 			</p>
 			<?php submit_button('Save all settings'); ?>

--- a/wp-oauth-settings.php
+++ b/wp-oauth-settings.php
@@ -821,7 +821,7 @@
 			<p>
 				<strong>Instructions:</strong>
 				<ol>
-					<li>Register as a Windows Live Developer at <a href='https://manage.dev.live.com' target="_blank">manage.dev.live.com</a>.</li>
+					<li>Register as a Windows Live Developer at <a href='https://apps.dev.microsoft.com/' target="_blank">apps.dev.microsoft.com/</a>.</li>
 					<li>At Windows Live, create a new App. This will enable your site to access the Windows Live API.</li>
 					<li>At Windows Live, provide your site's homepage URL (<?php echo $blog_url; ?>) for the new App's Redirect URI. Don't forget the trailing slash!</li>
 					<li>Paste your Client ID/Secret provided by Windows Live into the fields above, then click the Save all settings button.</li>

--- a/wp-oauth-settings.php
+++ b/wp-oauth-settings.php
@@ -1063,6 +1063,19 @@
 					<p class="tip-message"><strong>Instructions:</strong> Check the box above, click the Save all settings button, and the settings will be restored to default.</p>
 					<p class="tip-message tip-warning"><strong>Warning:</strong> This will restore the default settings, erasing any API keys/secrets that you may have entered above.</p>
 				</td>
+				</tr>
+				<tr valign='top' class="has-tip">
+				<th scope='row'>Enable debug: <a href="#" class="tip-button">[?]</a></th>
+				<td>
+					<input type='checkbox' name='wpoa_debug_plugin' value='1' <?php checked(get_option('wpoa_debug_plugin') == 1); ?> />
+					<p>
+						<strong>Instructions:</strong>
+						<ol>
+							<li>Check the box above and <a href="https://codex.wordpress.org/Debugging_in_WordPress">enable debug</a> for wordpress.</li>
+							<li>This will log request in debug.log file.</li>
+						</ol>
+					</p>
+				</td>
 				</tr>		
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Delete settings on uninstall: <a href="#" class="tip-button">[?]</a></th>

--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -128,6 +128,7 @@ Class WPOA {
 		'wpoa_http_util_verify_ssl' => 1,								// 0, 1
 		'wpoa_restore_default_settings' => 0,							// 0, 1
 		'wpoa_delete_settings_on_uninstall' => 0,						// 0, 1
+		'wpoa_debug_plugin' => 0,                						// 0, 1
 	);
 	
 	// when the plugin class gets created, fire the initialization:

--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -132,7 +132,7 @@ Class WPOA {
 	
 	// when the plugin class gets created, fire the initialization:
 	function __construct() {
-		$logger->log("Create instance");
+		Logger::Instance()->log("Create instance");
 		// hook activation and deactivation for the plugin:
 		register_activation_hook(__FILE__, array($this, 'wpoa_activate'));
 		register_deactivation_hook(__FILE__, array($this, 'wpoa_deactivate'));
@@ -219,16 +219,16 @@ Class WPOA {
 
 	
 	function redirect_to_login_if_not_logged() {
-		$logger->log("check if User is logged");
+		Logger::Instance()->log("check if User is logged");
 		if (!is_user_logged_in()) {
 			$url = $_SERVER["REQUEST_URI"];
-			$logger->log("User not logged, checking page : " . $url);
+			Logger::Instance()->log("User not logged, checking page : " . $url);
 			if (strpos($url, "wp-login.php") === false 
 				&& strpos($url, "connect") == false
 				&& strpos($url, "state") == false
 				&& strpos($url, "connect") == false
 				) {
-				$logger->log("User not logged, redirecting to login page");
+				Logger::Instance()->log("User not logged, redirecting to login page");
 				$url = $_SERVER['HTTP_HOST'] . "/wp-login.php";
 				wp_safe_redirect( wp_login_url(), 302 ); exit();
 				//$this->fail("");
@@ -393,7 +393,7 @@ Class WPOA {
 	// handle the querystring triggers:
 	function wpoa_qvar_handlers() {
 		if (get_query_var('connect')) {
-			$logger->log("using connect");
+			Logger::Instance()->log("using connect");
 			$provider = get_query_var('connect');
 			$this->wpoa_include_connector($provider);
 		}
@@ -414,7 +414,7 @@ Class WPOA {
 		$provider = str_replace(" ", "", $provider);
 		$provider = str_replace(".", "", $provider);
 		// include the provider script:
-		$logger->log("Loading provider " . $provider);
+		Logger::Instance()->log("Loading provider " . $provider);
 		include 'login-' . $provider . '.php';
 	}
 	
@@ -428,7 +428,7 @@ Class WPOA {
 		global $wpdb;
 		$usermeta_table = $wpdb->usermeta;
 		$query_string = "SELECT $usermeta_table.user_id FROM $usermeta_table WHERE $usermeta_table.meta_key = 'wpoa_identity' AND $usermeta_table.meta_value LIKE '%" . $oauth_identity[WPOA_Session::PROVIDER] . "|" . $oauth_identity[WPOA_Session::USER_ID] . "%'";
-		$logger->log($query_string);
+		Logger::Instance()->log($query_string);
 		//print_r( $query_string ); exit;
 		$query_result = $wpdb->get_var($query_string);
 		//print_r( $query_result ); exit;
@@ -439,12 +439,12 @@ Class WPOA {
 	
 	// login (or register and login) a wordpress user based on their oauth identity:
 	function wpoa_login_user($oauth_identity) {
-		$logger->log("login_user ... ");
+		Logger::Instance()->log("login_user ... ");
 		ob_start();
 		var_dump($oauth_identity);
 		$log = ob_get_clean();
 		ob_end_clean();
-		$logger->log($log);
+		Logger::Instance()->log($log);
 		
 		// store the user info in the user session so we can grab it later if we need to register the user:
 		WPOA_Session::set_id($oauth_identity[WPOA_Session::USER_ID]);
@@ -452,7 +452,7 @@ Class WPOA {
 		$matched_user = $this->wpoa_match_wordpress_user($oauth_identity);
 		// handle the matched user if there is one:
 		if ( $matched_user ) {
-			$logger->log("there was a matching wordpress user account, log it in now");
+			Logger::Instance()->log("there was a matching wordpress user account, log it in now");
 			$user_id = $matched_user->ID;
 			$user_login = $matched_user->user_login;
 			wp_set_current_user( $user_id, $user_login );
@@ -463,7 +463,7 @@ Class WPOA {
 		}
 		// handle the already logged in user if there is one:
 		if ( is_user_logged_in() ) {
-			$logger->log("there was a wordpress user logged in, but it is not associated with the now-authenticated user's email address, so associate it now");
+			Logger::Instance()->log("there was a wordpress user logged in, but it is not associated with the now-authenticated user's email address, so associate it now");
 			global $current_user;
 			get_currentuserinfo();
 			$user_id = $current_user->ID;
@@ -482,7 +482,7 @@ Class WPOA {
 	
 	// ends the login request by clearing the login state and redirecting the user to the desired page:
 	function wpoa_end_login($msg) {
-		$logger->log("wpoa_end_login : " . $msg);
+		Logger::Instance()->log("wpoa_end_login : " . $msg);
 		$last_url = WPOA_Session::get_last_url();
 		WPOA_Session::clear_last_url();
 		WPOA_Session::set_result($msg);
@@ -568,11 +568,11 @@ Class WPOA {
 	// links a third-party account to an existing wordpress user account:
 	function wpoa_link_account($user_id) {
 		$id = WPOA_Session::get_id();
-		$logger->log("Linking account with user id" . $id);
+		Logger::Instance()->log("Linking account with user id" . $id);
 		if ($id && $id != '') {
 			add_user_meta( $user_id, 'wpoa_identity', WPOA_Session::get_provider() . '|' . $id . '|' . time());
 		} else {
-			$logger->log("wpoa_link_account : no user id");
+			Logger::Instance()->log("wpoa_link_account : no user id");
 		}
 	}
 
@@ -931,7 +931,7 @@ Class WPOA {
 
 	function fail($message)
 	{
-		$logger->log($message);
+		Logger::Instance()->log($message);
 		WPOA_Session::set_result($message);
 		// header("Location: " . WPOA_Session::get_last_url());
 		wp_safe_redirect( wp_login_url(), 302 ); exit();


### PR DESCRIPTION
Hi,
I add windows azure authentication and to avoid copy/paste, 

I create an abstract class in `login-common` who contains all common code. I mostly tested with curl all refactored class. Only ItemBase and Oauth Server need a refactoring.

The registering changed to handle email when available.

Regards
