### PR TITLE
New Option to Allow Override "Anyone Can Register" Wordpress Setting

### DIFF
--- a/register.php
+++ b/register.php
@@ -1,1 +1,81 @@
-<?php// TODO: very important that we sanitize all $_POST variables here before using them!// TODO: this doesn't call wpoa_end_login() which might result in the LAST_URL not being cleared...global $wpdb;// initiate the user session:session_start();// prevent users from registering if the option is turned off in the dashboard:if (!get_option("users_can_register")) {	$_SESSION["WPOA"]["RESULT"] = "Sorry, user registration is disabled at this time. Your account could not be registered. Please notify the admin or try again later.";	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]);	exit;}// registration was initiated from an oauth provider, set the username and password automatically.if ($_SESSION["WPOA"]["USER_ID"] != "") {	$username = uniqid('', true);	$password = wp_generate_password();}// registration was initiated from the standard sign up form, set the username and password that was requested by the user.if ( $_SESSION["WPOA"]["USER_ID"] == "" ) {	// this registration was initiated from the standard Registration page, create account and login the user automatically	$username = $_POST['identity'];	$password = $_POST['password'];}// now attempt to generate the user and get the user id:$user_id = wp_create_user( $username, $password, $username ); // we use wp_create_user instead of wp_insert_user so we can handle the error when the user being registered already exists// check if the user was actually created:if (is_wp_error($user_id)) {	// there was an error during registration, redirect and notify the user:	$_SESSION["WPOA"]["RESULT"] = $user_id->get_error_message();	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]);	exit;}// now try to update the username to something more permanent and recognizable:$username = "user" . $user_id;$update_username_result = $wpdb->update($wpdb->users, array('user_login' => $username, 'user_nicename' => $username, 'display_name' => $username), array('ID' => $user_id));$update_nickname_result = update_user_meta($user_id, 'nickname', $username);// apply the custom default user role:$role = get_option('wpoa_new_user_role');$update_role_result = wp_update_user(array('ID' => $user_id, 'role' => $role));// proceed if no errors were detected:if ($update_username_result == false || $update_nickname_result == false) {	// there was an error during registration, redirect and notify the user:	$_SESSION["WPOA"]["RESULT"] = "Could not rename the username during registration. Please contact an admin or try again later.";	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;}elseif ($update_role_result == false) {	// there was an error during registration, redirect and notify the user:	$_SESSION["WPOA"]["RESULT"] = "Could not assign default user role during registration. Please contact an admin or try again later.";	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;}else {	// registration was successful, the user account was created, proceed to login the user automatically...	// associate the wordpress user account with the now-authenticated third party account:	$this->wpoa_link_account($user_id);	// attempt to login the new user (this could be error prone):	$creds = array();	$creds['user_login'] = $username;	$creds['user_password'] = $password;	$creds['remember'] = true;	$user = wp_signon( $creds, false );	// send a notification e-mail to the admin and the new user (we can also build our own email if necessary):	if (!get_option('wpoa_suppress_welcome_email')) {		//wp_mail($username, "New User Registration", "Thank you for registering!\r\nYour username: " . $username . "\r\nYour password: " . $password, $headers);		wp_new_user_notification( $user_id, $password );	}	// finally redirect the user back to the page they were on and notify them of successful registration:	$_SESSION["WPOA"]["RESULT"] = "You have been registered successfully!";	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;}?>
+<?php
+
+// TODO: very important that we sanitize all $_POST variables here before using them!
+// TODO: this doesn't call wpoa_end_login() which might result in the LAST_URL not being cleared...
+
+global $wpdb;
+
+// initiate the user session:
+session_start();
+
+// prevent users from registering if the option is turned off in the dashboard:
+if (!get_option("users_can_register") && !get_option("wpoa_override_users_can_register")) {
+	$_SESSION["WPOA"]["RESULT"] = "Sorry, user registration is disabled at this time. Your account could not be registered. Please notify the admin or try again later.";
+	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]);
+	exit;
+}
+
+// registration was initiated from an oauth provider, set the username and password automatically.
+if ($_SESSION["WPOA"]["USER_ID"] != "") {
+	$username = uniqid('', true);
+	$password = wp_generate_password();
+}
+
+// registration was initiated from the standard sign up form, set the username and password that was requested by the user.
+if ( $_SESSION["WPOA"]["USER_ID"] == "" ) {
+	// this registration was initiated from the standard Registration page, create account and login the user automatically
+	$username = $_POST['identity'];
+	$password = $_POST['password'];
+}
+
+// now attempt to generate the user and get the user id:
+$user_id = wp_create_user( $username, $password, $username ); // we use wp_create_user instead of wp_insert_user so we can handle the error when the user being registered already exists
+
+// check if the user was actually created:
+if (is_wp_error($user_id)) {
+	// there was an error during registration, redirect and notify the user:
+	$_SESSION["WPOA"]["RESULT"] = $user_id->get_error_message();
+	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]);
+	exit;
+}
+
+// now try to update the username to something more permanent and recognizable:
+$username = "user" . $user_id;
+$update_username_result = $wpdb->update($wpdb->users, array('user_login' => $username, 'user_nicename' => $username, 'display_name' => $username), array('ID' => $user_id));
+$update_nickname_result = update_user_meta($user_id, 'nickname', $username);
+
+// apply the custom default user role:
+$role = get_option('wpoa_new_user_role');
+$update_role_result = wp_update_user(array('ID' => $user_id, 'role' => $role));
+
+// proceed if no errors were detected:
+if ($update_username_result == false || $update_nickname_result == false) {
+	// there was an error during registration, redirect and notify the user:
+	$_SESSION["WPOA"]["RESULT"] = "Could not rename the username during registration. Please contact an admin or try again later.";
+	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;
+}
+elseif ($update_role_result == false) {
+	// there was an error during registration, redirect and notify the user:
+	$_SESSION["WPOA"]["RESULT"] = "Could not assign default user role during registration. Please contact an admin or try again later.";
+	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;
+}
+else {
+	// registration was successful, the user account was created, proceed to login the user automatically...
+	// associate the wordpress user account with the now-authenticated third party account:
+	$this->wpoa_link_account($user_id);
+	// attempt to login the new user (this could be error prone):
+	$creds = array();
+	$creds['user_login'] = $username;
+	$creds['user_password'] = $password;
+	$creds['remember'] = true;
+	$user = wp_signon( $creds, false );
+	// send a notification e-mail to the admin and the new user (we can also build our own email if necessary):
+	if (!get_option('wpoa_suppress_welcome_email')) {
+		//wp_mail($username, "New User Registration", "Thank you for registering!\r\nYour username: " . $username . "\r\nYour password: " . $password, $headers);
+		wp_new_user_notification( $user_id, $password );
+	}
+	// finally redirect the user back to the page they were on and notify them of successful registration:
+	$_SESSION["WPOA"]["RESULT"] = "You have been registered successfully!";
+	header("Location: " . $_SESSION["WPOA"]["LAST_URL"]); exit;
+}
+?>

--- a/wp-oauth-settings.php
+++ b/wp-oauth-settings.php
@@ -178,6 +178,14 @@
 				</td>
 				</tr>
 				
+				<tr valign='top' class='has-tip' class="has-tip">
+				<th scope='row'>Override Anyone can register: <a href="#" class="tip-button">[?]</a></th>
+				<td>
+					<input type='checkbox' name='wpoa_override_users_can_register' value='1' <?php checked(get_option('wpoa_override_users_can_register') == 1); ?> />
+					<p class="tip-message">Allows users to create accounts with WP-OAuth even if "Anyone can register" is not enabled in Wordpress: General - Membership. settings.</p>
+				</td>
+				</tr>
+
 				<tr valign='top' class="has-tip">
 				<th scope='row'>Login redirects to: <a href="#" class="tip-button">[?]</a></th>
 				<td>

--- a/wp-oauth.css
+++ b/wp-oauth.css
@@ -67,6 +67,7 @@ body.wpoa-lightbox-visible {overflow:hidden;}
 .wpoa-settings .form-table {margin-top:0;}
 .wpoa-settings .form-padding {padding:0 1em 1em 1em; position:relative; z-index:1;}
 .wpoa-settings ul {list-style:inherit; margin-left:2em;}
+.wpoa-settings h2 {padding-bottom: 2ex;}
 .wpoa-settings h3 {margin:0; cursor:pointer; color:#999; padding:0.5em; font-style:italic; text-transform:uppercase; border-bottom:1px solid #eee; font-size:1.5em; -webkit-transition:all 0.5s ease;}
 .wpoa-settings h3:hover {color:#000;}
 .wpoa-settings h4 {margin:0; color:#999; font-size:1.1em; font-style:italic; text-transform:uppercase; border-bottom:1px solid #eee; padding-bottom:5px;}

--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -123,6 +123,7 @@ Class WPOA {
 		'wpoa_http_util_verify_ssl' => 1,								// 0, 1
 		'wpoa_restore_default_settings' => 0,							// 0, 1
 		'wpoa_delete_settings_on_uninstall' => 0,						// 0, 1
+		'wpoa_override_users_can_register' => 0,						// 0, 1
 	);
 	
 	// when the plugin class gets created, fire the initialization:


### PR DESCRIPTION
This adds a new option that let's a user override the Wordpress option "users_can_register" to let WP-OAuth register new users while having the site closed to new Wordpress accounts.  

The use case for this is wanting to have some users (admins) log in with Wordpress accounts, thus keeping the wordpress login form visible, while user accounts require OAuth logins.  Enabling "Anyone Can Register" leaves the site owner open to spam registrations.  I know, I had this problem which is why I made this pull request =)

Please note, the file register.php had multiple line ending types detected in the same file and even my beloved vim could not cope.  The only change is line 12, the rest are just fixing the line endings.

Also, there is a small change on the style sheet to fix the options page.  On my firefox the "toggle" options were pushing down col 2 and causing col 1 to stack beneath it.
